### PR TITLE
Add unit tests for `LogEntries` and `Resume` features

### DIFF
--- a/src/PersonalSite.Application/Features/Common/LogEntries/Queries/GetLogEntries/GetLogEntriesQueryValidator.cs
+++ b/src/PersonalSite.Application/Features/Common/LogEntries/Queries/GetLogEntries/GetLogEntriesQueryValidator.cs
@@ -1,8 +1,8 @@
 namespace PersonalSite.Application.Features.Common.LogEntries.Queries.GetLogEntries;
 
-public class GetLogsQueryValidator : AbstractValidator<GetLogEntriesQuery>
+public class GetLogEntriesQueryValidator : AbstractValidator<GetLogEntriesQuery>
 {
-    public GetLogsQueryValidator()
+    public GetLogEntriesQueryValidator()
     {
         RuleFor(x => x.Page).GreaterThan(0);
         RuleFor(x => x.PageSize).InclusiveBetween(1, 100);

--- a/src/PersonalSite.Application/Features/Common/SocialMediaLinks/Commands/CreateSocialMediaLink/CreateSocialMediaLinkCommandValidator.cs
+++ b/src/PersonalSite.Application/Features/Common/SocialMediaLinks/Commands/CreateSocialMediaLink/CreateSocialMediaLinkCommandValidator.cs
@@ -19,6 +19,12 @@ public class CreateSocialMediaLinkCommandValidator : AbstractValidator<CreateSoc
     
     private bool BeAValidUrl(string url)
     {
-        return Uri.TryCreate(url, UriKind.Absolute, out var _);
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uriResult))
+            return false;
+
+        return uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps;
     }
 }

--- a/tests/PersonalSite.Application.Tests/Common/LoggerMockExtensions.cs
+++ b/tests/PersonalSite.Application.Tests/Common/LoggerMockExtensions.cs
@@ -1,0 +1,20 @@
+namespace PersonalSite.Application.Tests.Common;
+
+public static class LoggerMockExtensions
+{
+    public static void VerifyLog<T>(
+        this Mock<ILogger<T>> loggerMock,
+        LogLevel logLevel,
+        string message,
+        Times times)
+    {
+        loggerMock.Verify(
+            x => x.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(message)),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            times);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/CommonTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/CommonTestDataFactory.cs
@@ -1,5 +1,8 @@
 using System.Globalization;
 using PersonalSite.Application.Features.Common.Language.Dtos;
+using PersonalSite.Application.Features.Common.LogEntries.Dtos;
+using PersonalSite.Application.Features.Common.Resume.Dtos;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
 using PersonalSite.Domain.Entities.Common;
 
 namespace PersonalSite.Application.Tests.Fixtures.TestDataFactories;
@@ -25,4 +28,84 @@ public static class CommonTestDataFactory
             Name = language.Name
         };
     }
+    
+    public static LogEntry CreateLogEntry(
+        Guid? id = null,
+        DateTime? timestamp = null,
+        string level = "Information",
+        string message = "Sample log message",
+        string messageTemplate = "{MessageTemplate}",
+        string? exception = null,
+        string? properties = null,
+        string? sourceContext = "DefaultContext")
+    {
+        return new LogEntry
+        {
+            Id = id ?? Guid.NewGuid(),
+            Timestamp = timestamp ?? DateTime.UtcNow,
+            Level = level,
+            Message = message,
+            MessageTemplate = messageTemplate,
+            Exception = exception,
+            Properties = properties,
+            SourceContext = sourceContext
+        };
+    }
+
+    public static LogEntryDto MapToDto(LogEntry log)
+    {
+        return new LogEntryDto
+        {
+            Id = log.Id,
+            Timestamp = log.Timestamp,
+            Level = log.Level,
+            Message = log.Message,
+            MessageTemplate = log.MessageTemplate,
+            Exception = log.Exception,
+            Properties = log.Properties,
+            SourceContext = log.SourceContext,
+        };
+    }
+    
+    public static Resume CreateResume(Guid? id = null, string? fileUrl = null, string? fileName = null, bool isActive = true)
+    {
+        return new Resume
+        {
+            Id = id ?? Guid.NewGuid(),
+            FileUrl = fileUrl ?? "https://example.com/resume.pdf",
+            FileName = fileName ?? "resume.pdf",
+            UploadedAt = DateTime.UtcNow,
+            IsActive = isActive
+        };
+    }
+
+    public static ResumeDto MapToResumeDto(Resume entity)
+    {
+        return new ResumeDto
+        {
+            Id = entity.Id,
+            FileUrl = entity.FileUrl,
+            FileName = entity.FileName,
+            UploadedAt = entity.UploadedAt,
+            IsActive = entity.IsActive
+        };
+    }
+    
+    public static SocialMediaLink CreateSocialMediaLink(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Platform = "Twitter",
+        Url = "https://twitter.com/example",
+        DisplayOrder = 1,
+        IsActive = true
+    };
+
+    public static SocialMediaLinkDto MapToDto(SocialMediaLink entity) => new()
+    {
+        Id = entity.Id,
+        Platform = entity.Platform,
+        Url = entity.Url,
+        DisplayOrder = entity.DisplayOrder,
+        IsActive = entity.IsActive
+    };
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/DeleteLogsCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/DeleteLogsCommandHandlerTests.cs
@@ -1,0 +1,87 @@
+using PersonalSite.Application.Features.Common.LogEntries.Commands.DeleteLogs;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.LogEntries;
+
+public class DeleteLogsCommandHandlerTests
+{
+    private readonly Mock<ILogEntryRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<DeleteLogsCommandHandler>> _loggerMock = new();
+    private readonly DeleteLogsCommandHandler _handler;
+
+    public DeleteLogsCommandHandlerTests()
+    {
+        _handler = new DeleteLogsCommandHandler(_repositoryMock.Object, _unitOfWorkMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenAllLogsFoundAndDeleted()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var logs = ids.Select(id => new LogEntry { Id = id }).ToList();
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(logs);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(new DeleteLogsCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _repositoryMock.Verify(r => r.Remove(It.IsAny<LogEntry>()), Times.Exactly(ids.Count));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenSomeLogsNotFound()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var logs = new List<LogEntry>
+        {
+            new() { Id = ids[0], /* other properties */ }
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(logs);
+
+        // Act
+        var result = await _handler.Handle(new DeleteLogsCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Some log entries were not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid() };
+        var exception = new Exception("Database error");
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(new DeleteLogsCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Failed to delete log entries.");
+        _loggerMock.Verify(
+            x => x.Log<It.IsAnyType>(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Failed to delete log entries.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/GetLogEntriesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/GetLogEntriesQueryHandlerTests.cs
@@ -1,0 +1,129 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.LogEntries.Dtos;
+using PersonalSite.Application.Features.Common.LogEntries.Queries.GetLogEntries;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Common.Results;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.LogEntries;
+
+public class GetLogEntriesQueryHandlerTests
+{
+    private readonly Mock<ILogEntryRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetLogEntriesQueryHandler>> _loggerMock = new();
+    private readonly Mock<IMapper<LogEntry, LogEntryDto>> _mapperMock = new();
+    private readonly GetLogEntriesQueryHandler _handler;
+
+    public GetLogEntriesQueryHandlerTests()
+    {
+        _handler = new GetLogEntriesQueryHandler(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenLogsFound()
+    {
+        // Arrange
+        var query = new GetLogEntriesQuery();
+
+        var logEntities = new List<LogEntry>
+        {
+            CommonTestDataFactory.CreateLogEntry(),
+            CommonTestDataFactory.CreateLogEntry()
+        };
+
+        var pagedResult = PaginatedResult<LogEntry>.Success(logEntities, 1, 20, 2);
+
+        _repositoryMock.Setup(r => r.GetFilteredAsync(
+                query.Page, query.PageSize, query.LevelFilter, query.SourceContextFilter, query.From, query.To, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+
+        var mappedDtos = logEntities.Select(e => new LogEntryDto
+        {
+            Id = e.Id,
+            Timestamp = e.Timestamp,
+            Level = e.Level,
+            Message = e.Message,
+            MessageTemplate = e.MessageTemplate,
+            Exception = e.Exception,
+            Properties = e.Properties,
+            SourceContext = e.SourceContext
+        }).ToList();
+
+        _mapperMock.Setup(m => m.MapToDtoList(logEntities)).Returns(mappedDtos);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(mappedDtos);
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(20);
+        result.TotalCount.Should().Be(2);
+
+        _repositoryMock.VerifyAll();
+        _mapperMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenNoLogsFound()
+    {
+        // Arrange
+        var query = new GetLogEntriesQuery();
+
+        var pagedResult = PaginatedResult<LogEntry>.Failure("Failed to get logs");
+
+        _repositoryMock.Setup(r => r.GetFilteredAsync(
+                query.Page, query.PageSize, query.LevelFilter, query.SourceContextFilter, query.From, query.To, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Log entries not found");
+
+        _loggerMock.Verify(l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Log entries not found")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        var query = new GetLogEntriesQuery();
+
+        _repositoryMock.Setup(r => r.GetFilteredAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Some error"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Error getting log entries.");
+
+        _loggerMock.Verify(l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error getting log entries.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/CreateResumeCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/CreateResumeCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+using PersonalSite.Application.Features.Common.Resume.Commands.CreateResume;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
+
+public class CreateResumeCommandHandlerTests
+{
+    private readonly Mock<IResumeRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<CreateResumeCommandHandler>> _loggerMock;
+    private readonly CreateResumeCommandHandler _handler;
+
+    public CreateResumeCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<IResumeRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<CreateResumeCommandHandler>>();
+
+        _handler = new CreateResumeCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WithNewGuid_WhenResumeCreated()
+    {
+        // Arrange
+        var command = new CreateResumeCommand("http://file.url/resume.pdf", "resume.pdf", true);
+
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.Resume>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeEmpty();
+
+        _repositoryMock.Verify(r => r.AddAsync(
+                It.Is<Domain.Entities.Common.Resume>(res => 
+                    res.FileUrl == command.FileUrl &&
+                    res.FileName == command.FileName &&
+                    res.IsActive == command.IsActive),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_AndLogError_WhenExceptionThrown()
+    {
+        // Arrange
+        var command = new CreateResumeCommand("url", "file", true);
+        var exception = new Exception("Database error");
+
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.Resume>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Failed to create resume.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating resume.")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/DeleteResumeCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/DeleteResumeCommandHandlerTests.cs
@@ -1,0 +1,101 @@
+using PersonalSite.Application.Features.Common.Resume.Commands.DeleteResume;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
+
+public class DeleteResumeCommandHandlerTests
+{
+    private readonly Mock<IResumeRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<DeleteResumeCommandHandler>> _loggerMock;
+    private readonly DeleteResumeCommandHandler _handler;
+
+    public DeleteResumeCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<IResumeRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<DeleteResumeCommandHandler>>();
+
+        _handler = new DeleteResumeCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenResumeExistsAndDeleted()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+        var resume = new Domain.Entities.Common.Resume { Id = resumeId };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resume);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(new DeleteResumeCommand(resumeId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.Remove(resume), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenResumeNotFound()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.Resume?)null);
+
+        // Act
+        var result = await _handler.Handle(new DeleteResumeCommand(resumeId), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Resume not found.");
+
+        _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.Remove(It.IsAny<Domain.Entities.Common.Resume>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_AndLogError_WhenExceptionThrown()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+        var exception = new Exception("Database failure");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(new DeleteResumeCommand(resumeId), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Failed to delete resume.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error deleting resume.")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumeByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumeByIdQueryHandlerTests.cs
@@ -1,0 +1,98 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.Resume.Dtos;
+using PersonalSite.Application.Features.Common.Resume.Queries.GetResumeById;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
+
+public class GetResumeByIdQueryHandlerTests
+{
+    private readonly Mock<IResumeRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetResumeByIdQueryHandler>> _loggerMock;
+    private readonly Mock<IMapper<Domain.Entities.Common.Resume, ResumeDto>> _mapperMock;
+    private readonly GetResumeByIdQueryHandler _handler;
+
+    public GetResumeByIdQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<IResumeRepository>();
+        _loggerMock = new Mock<ILogger<GetResumeByIdQueryHandler>>();
+        _mapperMock = new Mock<IMapper<Domain.Entities.Common.Resume, ResumeDto>>();
+
+        _handler = new GetResumeByIdQueryHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+    
+    [Fact]
+    public async Task Handle_ShouldReturnResume_WhenResumeExists()
+    {
+        // Arrange
+        var resume = CommonTestDataFactory.CreateResume();
+        var resumeDto = CommonTestDataFactory.MapToResumeDto(resume);
+        var query = new GetResumeByIdQuery(resume.Id);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resume.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resume);
+
+        _mapperMock
+            .Setup(m => m.MapToDto(resume))
+            .Returns(resumeDto);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(resumeDto);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenResumeNotFound()
+    {
+        // Arrange
+        var query = new GetResumeByIdQuery(Guid.NewGuid());
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(query.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.Resume?)null);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Resume not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        var query = new GetResumeByIdQuery(Guid.NewGuid());
+        var exception = new Exception("Some error");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(query.Id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Error getting resume by id.");
+
+        // Verify that error was logged
+        _loggerMock.Verify(
+            l => l.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error getting resume by id.")),
+                It.Is<Exception>(ex => ex == exception),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumesQueryHandlerTests.cs
@@ -1,0 +1,138 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.Resume.Dtos;
+using PersonalSite.Application.Features.Common.Resume.Queries.GetResumes;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Common.Results;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
+
+public class GetResumesQueryHandlerTests
+{
+    private readonly Mock<IResumeRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetResumesQueryHandler>> _loggerMock;
+    private readonly Mock<IMapper<Domain.Entities.Common.Resume, ResumeDto>> _mapperMock;
+    private readonly GetResumesQueryHandler _handler;
+
+    public GetResumesQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<IResumeRepository>();
+        _loggerMock = new Mock<ILogger<GetResumesQueryHandler>>();
+        _mapperMock = new Mock<IMapper<Domain.Entities.Common.Resume, ResumeDto>>();
+
+        _handler = new GetResumesQueryHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenResumesFound()
+    {
+        // Arrange
+        var resumes = new List<Domain.Entities.Common.Resume>
+        {
+            CommonTestDataFactory.CreateResume(),
+            CommonTestDataFactory.CreateResume(),
+            CommonTestDataFactory.CreateResume()
+        };
+
+        var paginatedResult = PaginatedResult<Domain.Entities.Common.Resume>.Success(
+            resumes,
+            pageNumber: 1,
+            pageSize: 20,
+            totalCount: 3);
+
+        var resumeDtos = resumes.Select(CommonTestDataFactory.MapToResumeDto).ToList();
+
+        _repositoryMock
+            .Setup(r => r.GetFilteredAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResult);
+
+        _mapperMock
+            .Setup(m => m.MapToDtoList(resumes))
+            .Returns(resumeDtos);
+
+        var query = new GetResumesQuery(Page: 1, PageSize: 20, IsActive: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(resumeDtos);
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(20);
+        result.TotalCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenNoResumesFound()
+    {
+        // Arrange
+        var emptyResult = PaginatedResult<Domain.Entities.Common.Resume>.Failure("Resumes not found");
+
+        _repositoryMock
+            .Setup(r => r.GetFilteredAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyResult);
+
+        var query = new GetResumesQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Resumes not found");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Resumes not found")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        var exception = new Exception("Some error");
+
+        _repositoryMock
+            .Setup(r => r.GetFilteredAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        var query = new GetResumesQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("An error occurred while getting the resumes.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error getting resumes.")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/UpdateResumeCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/UpdateResumeCommandHandlerTests.cs
@@ -1,0 +1,122 @@
+using PersonalSite.Application.Features.Common.Resume.Commands.UpdateResume;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
+
+public class UpdateResumeCommandHandlerTests
+{
+    private readonly Mock<IResumeRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<UpdateResumeCommandHandler>> _loggerMock;
+    private readonly UpdateResumeCommandHandler _handler;
+
+    public UpdateResumeCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<IResumeRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<UpdateResumeCommandHandler>>();
+
+        _handler = new UpdateResumeCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenResumeExistsAndUpdated()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+        var existingResume = new Domain.Entities.Common.Resume
+        {
+            Id = resumeId,
+            FileUrl = "old-url",
+            FileName = "old-file.txt",
+            IsActive = false
+        };
+
+        var command = new UpdateResumeCommand(
+            resumeId,
+            FileUrl: "new-url",
+            FileName: "new-file.txt",
+            IsActive: true);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingResume);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(existingResume, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        existingResume.FileUrl.Should().Be("new-url");
+        existingResume.FileName.Should().Be("new-file.txt");
+        existingResume.IsActive.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.UpdateAsync(existingResume, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenResumeNotFound()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+        var command = new UpdateResumeCommand(resumeId, "url", "file", true);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.Resume?)null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Resume not found.");
+
+        _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Common.Resume>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_AndLogError_WhenExceptionThrown()
+    {
+        // Arrange
+        var resumeId = Guid.NewGuid();
+        var command = new UpdateResumeCommand(resumeId, "url", "file", true);
+        var exception = new Exception("DB failure");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Failed to update resume.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error updating resume.")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SiteInfo/GetSiteInfoQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SiteInfo/GetSiteInfoQueryHandlerTests.cs
@@ -1,0 +1,153 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.Language.Dtos;
+using PersonalSite.Application.Features.Common.Resume.Dtos;
+using PersonalSite.Application.Features.Common.SiteInfo.Queries.GetSiteInfo;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
+using PersonalSite.Application.Tests.Common;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SiteInfo;
+
+public class GetSiteInfoQueryHandlerTests
+{
+    private readonly Mock<ILanguageRepository> _languageRepoMock = new();
+    private readonly Mock<ISocialMediaLinkRepository> _socialLinkRepoMock = new();
+    private readonly Mock<IResumeRepository> _resumeRepoMock = new();
+    private readonly Mock<ILogger<GetSiteInfoQueryHandler>> _loggerMock = new();
+    private readonly Mock<IMapper<Domain.Entities.Common.Language, LanguageDto>> _languageMapperMock = new();
+    private readonly Mock<IMapper<Domain.Entities.Common.SocialMediaLink, SocialMediaLinkDto>> _socialLinkMapperMock = new();
+    private readonly Mock<IMapper<Domain.Entities.Common.Resume, ResumeDto>> _resumeMapperMock = new();
+
+    private GetSiteInfoQueryHandler CreateHandler() => new(
+        _languageRepoMock.Object,
+        _socialLinkRepoMock.Object,
+        _resumeRepoMock.Object,
+        _loggerMock.Object,
+        _languageMapperMock.Object,
+        _socialLinkMapperMock.Object,
+        _resumeMapperMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenNoLanguagesFound()
+    {
+        _languageRepoMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Domain.Entities.Common.Language>());
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetSiteInfoQuery(), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("No languages found.");
+
+        _loggerMock.VerifyLog(LogLevel.Warning, "No languages found.", Times.Once());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WithMappedData()
+    {
+        var languages = new List<Domain.Entities.Common.Language>
+        {
+            CommonTestDataFactory.CreateLanguage(),
+            CommonTestDataFactory.CreateLanguage("pl")
+        };
+
+        var socialLinks = new List<Domain.Entities.Common.SocialMediaLink>
+        {
+            CommonTestDataFactory.CreateSocialMediaLink(),
+        };
+
+        var resumeEntity = CommonTestDataFactory.CreateResume(
+            fileUrl: "resume.pdf",
+            fileName: "Resume.pdf",
+            isActive: true);
+
+        var languageDtos = new List<LanguageDto>
+        {
+            CommonTestDataFactory.MapToDto(languages[0]),
+            CommonTestDataFactory.MapToDto(languages[1])
+        };
+
+        var socialLinkDtos = new List<SocialMediaLinkDto>
+        {
+            CommonTestDataFactory.MapToDto(socialLinks[0])
+        };
+
+        var resumeDto = CommonTestDataFactory.MapToResumeDto(resumeEntity);
+            
+        _languageRepoMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(languages);
+        _socialLinkRepoMock.Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(socialLinks);
+        _resumeRepoMock.Setup(x => x.GetLastActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resumeEntity);
+
+        _languageMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IEnumerable<Domain.Entities.Common.Language>>()))
+            .Returns(languageDtos);
+        _socialLinkMapperMock.Setup(m => m.MapToDtoList(socialLinks))
+            .Returns(socialLinkDtos);
+        _resumeMapperMock.Setup(m => m.MapToDto(resumeEntity))
+            .Returns(resumeDto);
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetSiteInfoQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value?.Languages.Should().BeEquivalentTo(languageDtos);
+        result.Value?.SocialLinks.Should().BeEquivalentTo(socialLinkDtos);
+        result.Value?.Resume.Should().BeEquivalentTo(resumeDto);
+
+        _loggerMock.VerifyNoOtherCalls(); // No warnings/errors expected in this successful scenario
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogWarning_WhenNoSocialLinksFound()
+    {
+        var languages = new List<Domain.Entities.Common.Language>
+        {
+            new Domain.Entities.Common.Language { Id = Guid.NewGuid(), Name = "English", IsDeleted = false }
+        };
+
+        _languageRepoMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(languages);
+        _socialLinkRepoMock.Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Domain.Entities.Common.SocialMediaLink>());
+        _resumeRepoMock.Setup(x => x.GetLastActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.Resume?)null);
+
+        _languageMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IEnumerable<Domain.Entities.Common.Language>>()))
+            .Returns([CommonTestDataFactory.MapToDto(languages[0])]);
+        _socialLinkMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IEnumerable<Domain.Entities.Common.SocialMediaLink>>()))
+            .Returns([]);
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetSiteInfoQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value?.SocialLinks.Should().BeEmpty();
+        result.Value?.Resume.Should().BeNull();
+
+        _loggerMock.VerifyLog(LogLevel.Warning, "No social links found.", Times.Once());
+        _loggerMock.VerifyLog(LogLevel.Warning, "No active resume found.", Times.Once());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        _languageRepoMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetSiteInfoQuery(), CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.VerifyLog(LogLevel.Error, "Error occurred while getting site info.", Times.Once());
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/CreateSocialMediaLinkCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/CreateSocialMediaLinkCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.CreateSocialMediaLink;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
+
+public class CreateSocialMediaLinkCommandHandlerTests
+{
+    private readonly Mock<ISocialMediaLinkRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<CreateSocialMediaLinkCommandHandler>> _loggerMock;
+
+    private readonly CreateSocialMediaLinkCommandHandler _handler;
+
+    public CreateSocialMediaLinkCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<ISocialMediaLinkRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<CreateSocialMediaLinkCommandHandler>>();
+
+        _handler = new CreateSocialMediaLinkCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenCreationIsSuccessful()
+    {
+        // Arrange
+        var command = new CreateSocialMediaLinkCommand(
+            Platform: "GitHub",
+            Url: "https://github.com/user",
+            DisplayOrder: 1,
+            IsActive: true
+        );
+
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBe(Guid.Empty);
+
+        _repositoryMock.Verify(r => r.AddAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenExceptionIsThrown()
+    {
+        // Arrange
+        var command = new CreateSocialMediaLinkCommand(
+            Platform: "Twitter",
+            Url: "https://twitter.com/user",
+            DisplayOrder: 2,
+            IsActive: true
+        );
+
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Something went wrong"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Failed to create social media link.");
+
+        _loggerMock.Verify(
+            x => x.Log<It.IsAnyType>(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating social media link")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once
+        );
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/DeleteSocialMediaLinkCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/DeleteSocialMediaLinkCommandHandlerTests.cs
@@ -1,0 +1,95 @@
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.DeleteSocialMediaLink;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
+
+public class DeleteSocialMediaLinkCommandHandlerTests
+{
+    private readonly Mock<ISocialMediaLinkRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<DeleteSocialMediaLinkCommandHandler>> _loggerMock;
+    private readonly DeleteSocialMediaLinkCommandHandler _handler;
+
+    public DeleteSocialMediaLinkCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<ISocialMediaLinkRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<DeleteSocialMediaLinkCommandHandler>>();
+
+        _handler = new DeleteSocialMediaLinkCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenEntityFoundAndDeleted()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var entity = new Domain.Entities.Common.SocialMediaLink { Id = id };
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(new DeleteSocialMediaLinkCommand(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _repositoryMock.Verify(r => r.Remove(entity), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenEntityNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.SocialMediaLink?)null);
+
+        // Act
+        var result = await _handler.Handle(new DeleteSocialMediaLinkCommand(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Social media link not found.");
+
+        _repositoryMock.Verify(r => r.Remove(It.IsAny<Domain.Entities.Common.SocialMediaLink>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogError_AndReturnFailure_OnException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Something went wrong"));
+
+        // Act
+        var result = await _handler.Handle(new DeleteSocialMediaLinkCommand(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            x => x.Log<It.IsAnyType>(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error deleting social media link")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once
+        );
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryHandlerTests.cs
@@ -1,0 +1,82 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Queries.GetSocialMediaLinkById;
+using PersonalSite.Application.Tests.Common;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
+
+public class GetSocialMediaLinkByIdQueryHandlerTests
+{
+    private readonly Mock<ISocialMediaLinkRepository> _repositoryMock = new();
+    private readonly Mock<IMapper<Domain.Entities.Common.SocialMediaLink, SocialMediaLinkDto>> _mapperMock = new();
+    private readonly Mock<ILogger<GetSocialMediaLinkByIdQueryHandler>> _loggerMock = new();
+
+    private GetSocialMediaLinkByIdQueryHandler CreateHandler() =>
+        new(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenLinkExists()
+    {
+        // Arrange
+        var link = CommonTestDataFactory.CreateSocialMediaLink();
+        var dto = CommonTestDataFactory.MapToDto(link);
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(link.Id, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(link);
+
+        _mapperMock.Setup(m => m.MapToDto(link)).Returns(dto);
+
+        var handler = CreateHandler();
+        var query = new GetSocialMediaLinkByIdQuery(link.Id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dto);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenLinkNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync((Domain.Entities.Common.SocialMediaLink?)null);
+
+        var handler = CreateHandler();
+        var query = new GetSocialMediaLinkByIdQuery(id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Social media link not found.");
+        _loggerMock.VerifyLog(LogLevel.Warning, $"Social media link with ID {id} not found.", Times.Once());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+                       .ThrowsAsync(new Exception("DB error"));
+
+        var handler = CreateHandler();
+        var query = new GetSocialMediaLinkByIdQuery(id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("DB error");
+        _loggerMock.VerifyLog(LogLevel.Error, "Error occurred while getting social media link by id.", Times.Once());
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinksQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinksQueryHandlerTests.cs
@@ -1,0 +1,105 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Queries.GetSocialMediaLinks;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Common.Results;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
+
+public class GetSocialMediaLinksQueryHandlerTests
+{
+    private readonly Mock<ISocialMediaLinkRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetSocialMediaLinksQueryHandler>> _loggerMock = new();
+    private readonly Mock<IMapper<Domain.Entities.Common.SocialMediaLink, SocialMediaLinkDto>> _mapperMock = new();
+
+    private readonly GetSocialMediaLinksQueryHandler _handler;
+
+    public GetSocialMediaLinksQueryHandlerTests()
+    {
+        _handler = new GetSocialMediaLinksQueryHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenDataExists()
+    {
+        // Arrange
+        var socialLinks = new List<Domain.Entities.Common.SocialMediaLink>
+        {
+            CommonTestDataFactory.CreateSocialMediaLink()
+        };
+        var dtos = new List<SocialMediaLinkDto>
+        {
+            CommonTestDataFactory.MapToDto(socialLinks[0])
+        };
+
+        _repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaginatedResult<Domain.Entities.Common.SocialMediaLink>.Success(
+                value: socialLinks,
+                pageNumber: 1,
+                pageSize: 10,
+                totalCount: socialLinks.Count));
+
+
+        _mapperMock.Setup(m => m.MapToDtoList(socialLinks)).Returns(dtos);
+
+        // Act
+        var result = await _handler.Handle(new GetSocialMediaLinksQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dtos);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenRepositoryReturnsFailure()
+    {
+        // Arrange
+        _repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaginatedResult<Domain.Entities.Common.SocialMediaLink>.Failure("Social media links not found"));
+
+        // Act
+        var result = await _handler.Handle(new GetSocialMediaLinksQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Social media links not found");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Social media links not found")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_OnException()
+    {
+        // Arrange
+        _repositoryMock.Setup(r => r.GetFilteredAsync(It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB failure"));
+
+        // Act
+        var result = await _handler.Handle(new GetSocialMediaLinksQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Failed to get social media links");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error occurred while getting social media links")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/UpdateSocialMediaLinkCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/UpdateSocialMediaLinkCommandHandlerTests.cs
@@ -1,0 +1,129 @@
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.UpdateSocialMediaLink;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+
+namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
+
+public class UpdateSocialMediaLinkCommandHandlerTests
+{
+    private readonly Mock<ISocialMediaLinkRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<UpdateSocialMediaLinkCommandHandler>> _loggerMock;
+    private readonly UpdateSocialMediaLinkCommandHandler _handler;
+
+    public UpdateSocialMediaLinkCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<ISocialMediaLinkRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<UpdateSocialMediaLinkCommandHandler>>();
+
+        _handler = new UpdateSocialMediaLinkCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenEntityExistsAndUpdated()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var entity = new Domain.Entities.Common.SocialMediaLink
+        {
+            Id = id,
+            Platform = "old",
+            Url = "old-url",
+            DisplayOrder = 1,
+            IsActive = false
+        };
+
+        var command = new UpdateSocialMediaLinkCommand(
+            Id: id,
+            Platform: "LinkedIn",
+            Url: "https://linkedin.com/in/me",
+            DisplayOrder: 2,
+            IsActive: true
+        );
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        entity.Platform.Should().Be(command.Platform);
+        entity.Url.Should().Be(command.Url);
+        entity.DisplayOrder.Should().Be(command.DisplayOrder);
+        entity.IsActive.Should().Be(command.IsActive);
+
+        _repositoryMock.Verify(r => r.UpdateAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenEntityNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Common.SocialMediaLink?)null);
+
+        var command = new UpdateSocialMediaLinkCommand(
+            Id: id,
+            Platform: "Twitter",
+            Url: "https://twitter.com",
+            DisplayOrder: 1,
+            IsActive: true
+        );
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Social media link not found.");
+
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogError_AndReturnFailure_OnException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var command = new UpdateSocialMediaLinkCommand(
+            Id: id,
+            Platform: "YouTube",
+            Url: "https://youtube.com",
+            DisplayOrder: 5,
+            IsActive: true
+        );
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB connection failed"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            x => x.Log<It.IsAnyType>(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error occurred while updating social media link")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once
+        );
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Common/LogEntries/LogEntryMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Common/LogEntries/LogEntryMapperTests.cs
@@ -1,0 +1,83 @@
+using PersonalSite.Application.Features.Common.LogEntries.Mappers;
+using PersonalSite.Domain.Entities.Common;
+
+namespace PersonalSite.Application.Tests.Mappers.Common.LogEntries;
+
+public class LogEntryMapperTests
+{
+    private readonly LogEntryMapper _mapper = new();
+
+    [Fact]
+    public void MapToDto_ShouldMapCorrectly()
+    {
+        // Arrange
+        var logEntry = new LogEntry
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            Level = "Error",
+            Message = "Test error occurred",
+            MessageTemplate = "{Message}",
+            Exception = "StackTrace...",
+            Properties = "{\"userId\":123}",
+            SourceContext = "TestContext"
+        };
+
+        // Act
+        var dto = _mapper.MapToDto(logEntry);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(logEntry.Id);
+        dto.Timestamp.Should().Be(logEntry.Timestamp);
+        dto.Level.Should().Be(logEntry.Level);
+        dto.Message.Should().Be(logEntry.Message);
+        dto.MessageTemplate.Should().Be(logEntry.MessageTemplate);
+        dto.Exception.Should().Be(logEntry.Exception);
+        dto.Properties.Should().Be(logEntry.Properties);
+        dto.SourceContext.Should().Be(logEntry.SourceContext);
+    }
+
+    [Fact]
+    public void MapToDtoList_ShouldMapListCorrectly()
+    {
+        // Arrange
+        var logs = new List<LogEntry>
+        {
+            new LogEntry
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow,
+                Level = "Info",
+                Message = "Info message",
+                MessageTemplate = "{Info}",
+                Exception = null,
+                Properties = "{}",
+                SourceContext = "App"
+            },
+            new LogEntry
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow,
+                Level = "Warning",
+                Message = "Warn message",
+                MessageTemplate = "{Warn}",
+                Exception = null,
+                Properties = "{}",
+                SourceContext = "App"
+            }
+        };
+
+        // Act
+        var dtoList = _mapper.MapToDtoList(logs);
+
+        // Assert
+        dtoList.Should().HaveSameCount(logs);
+
+        for (int i = 0; i < logs.Count; i++)
+        {
+            dtoList[i].Id.Should().Be(logs[i].Id);
+            dtoList[i].Message.Should().Be(logs[i].Message);
+        }
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Common/Resume/ResumeMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Common/Resume/ResumeMapperTests.cs
@@ -1,0 +1,80 @@
+using PersonalSite.Application.Features.Common.Resume.Mappers;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Common.Resume;
+
+public class ResumeMapperTests
+    {
+        private readonly Mock<IS3UrlBuilder> _urlBuilderMock;
+        private readonly ResumeMapper _mapper;
+
+        public ResumeMapperTests()
+        {
+            _urlBuilderMock = new Mock<IS3UrlBuilder>();
+            _mapper = new ResumeMapper(_urlBuilderMock.Object);
+        }
+
+        [Fact]
+        public void MapToDto_ShouldMapAllProperties_AndBuildUrl()
+        {
+            // Arrange
+            var resume = CommonTestDataFactory.CreateResume(
+                fileName: "resume.pdf",
+                fileUrl: "file/path/resume.pdf",
+                isActive: true);
+
+            var expectedUrl = "https://bucket.s3.amazonaws.com/file/path/resume.pdf";
+            _urlBuilderMock.Setup(x => x.BuildUrl(resume.FileUrl)).Returns(expectedUrl);
+
+            // Act
+            var dto = _mapper.MapToDto(resume);
+
+            // Assert
+            dto.Id.Should().Be(resume.Id);
+            dto.FileUrl.Should().Be(expectedUrl);
+            dto.FileName.Should().Be(resume.FileName);
+            dto.UploadedAt.Should().Be(resume.UploadedAt);
+            dto.IsActive.Should().Be(resume.IsActive);
+
+            _urlBuilderMock.Verify(x => x.BuildUrl(resume.FileUrl), Times.Once);
+        }
+
+        [Fact]
+        public void MapToDtoList_ShouldMapAllEntities()
+        {
+            // Arrange
+            var resumes = new List<Domain.Entities.Common.Resume>
+            {
+                CommonTestDataFactory.CreateResume(
+                    fileUrl: "file1.pdf",
+                    fileName : "file1.pdf",
+                    isActive : true
+                    ),
+                CommonTestDataFactory.CreateResume(
+                    fileUrl: "file2.pdf",
+                    fileName : "file2.pdf",
+                    isActive : false)
+            };
+
+            _urlBuilderMock.Setup(x => x.BuildUrl(It.IsAny<string>()))
+                .Returns<string>(url => "https://bucket.s3.amazonaws.com/" + url);
+
+            // Act
+            var dtos = _mapper.MapToDtoList(resumes);
+
+            // Assert
+            dtos.Should().HaveCount(resumes.Count);
+
+            for (int i = 0; i < resumes.Count; i++)
+            {
+                dtos[i].Id.Should().Be(resumes[i].Id);
+                dtos[i].FileUrl.Should().Be("https://bucket.s3.amazonaws.com/" + resumes[i].FileUrl);
+                dtos[i].FileName.Should().Be(resumes[i].FileName);
+                dtos[i].UploadedAt.Should().Be(resumes[i].UploadedAt);
+                dtos[i].IsActive.Should().Be(resumes[i].IsActive);
+            }
+
+            _urlBuilderMock.Verify(x => x.BuildUrl(It.IsAny<string>()), Times.Exactly(resumes.Count));
+        }
+    }

--- a/tests/PersonalSite.Application.Tests/Mappers/Common/SocialMediaLink/SocialMediaLinkMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Common/SocialMediaLink/SocialMediaLinkMapperTests.cs
@@ -1,0 +1,83 @@
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Mappers;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Common.SocialMediaLink;
+
+public class SocialMediaLinkMapperTests
+    {
+        private readonly Mock<IS3UrlBuilder> _urlBuilderMock;
+        private readonly SocialMediaLinkMapper _mapper;
+
+        public SocialMediaLinkMapperTests()
+        {
+            _urlBuilderMock = new Mock<IS3UrlBuilder>();
+            _mapper = new SocialMediaLinkMapper(_urlBuilderMock.Object);
+        }
+
+        [Fact]
+        public void MapToDto_ShouldReturnDtoWithExpectedData()
+        {
+            // Arrange
+            var entity = new Domain.Entities.Common.SocialMediaLink
+            {
+                Id = Guid.NewGuid(),
+                Platform = "Twitter",
+                Url = "media/twitter.png",
+                DisplayOrder = 1,
+                IsActive = true
+            };
+
+            var expectedUrl = "https://cdn.site.com/media/twitter.png";
+
+            _urlBuilderMock.Setup(x => x.BuildUrl(entity.Url)).Returns(expectedUrl);
+
+            // Act
+            var dto = _mapper.MapToDto(entity);
+
+            // Assert
+            dto.Should().NotBeNull();
+            dto.Id.Should().Be(entity.Id);
+            dto.Platform.Should().Be(entity.Platform);
+            dto.Url.Should().Be(expectedUrl);
+            dto.DisplayOrder.Should().Be(entity.DisplayOrder);
+            dto.IsActive.Should().Be(entity.IsActive);
+        }
+
+        [Fact]
+        public void MapToDtoList_ShouldReturnMappedDtoList()
+        {
+            // Arrange
+            var entities = new List<Domain.Entities.Common.SocialMediaLink>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Platform = "LinkedIn",
+                    Url = "media/linkedin.png",
+                    DisplayOrder = 1,
+                    IsActive = true
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Platform = "GitHub",
+                    Url = "media/github.png",
+                    DisplayOrder = 2,
+                    IsActive = false
+                }
+            };
+
+            _urlBuilderMock.Setup(x => x.BuildUrl(It.IsAny<string>()))
+                .Returns<string>(url => $"https://cdn.site.com/{url}");
+
+            // Act
+            var dtos = _mapper.MapToDtoList(entities);
+
+            // Assert
+            dtos.Should().HaveCount(2);
+            dtos[0].Platform.Should().Be("LinkedIn");
+            dtos[0].Url.Should().Be("https://cdn.site.com/media/linkedin.png");
+            dtos[1].Platform.Should().Be("GitHub");
+            dtos[1].Url.Should().Be("https://cdn.site.com/media/github.png");
+        }
+    }

--- a/tests/PersonalSite.Application.Tests/Validators/Common/LogEntries/DeleteLogsCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/LogEntries/DeleteLogsCommandValidatorTests.cs
@@ -1,0 +1,41 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.LogEntries.Commands.DeleteLogs;
+
+namespace PersonalSite.Application.Tests.Validators.Common.LogEntries;
+
+public class DeleteLogsCommandValidatorTests
+{
+    private readonly DeleteLogsCommandValidator _validator;
+
+    public DeleteLogsCommandValidatorTests()
+    {
+        _validator = new DeleteLogsCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Ids_Is_Empty()
+    {
+        // Arrange
+        var command = new DeleteLogsCommand(new List<Guid>());
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Ids)
+            .WithErrorMessage("At least one log ID must be provided.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Ids_Contain_Elements()
+    {
+        // Arrange
+        var command = new DeleteLogsCommand(new List<Guid> { Guid.NewGuid() });
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(c => c.Ids);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/LogEntries/GetLogEntriesQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/LogEntries/GetLogEntriesQueryValidatorTests.cs
@@ -1,0 +1,52 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.LogEntries.Queries.GetLogEntries;
+
+namespace PersonalSite.Application.Tests.Validators.Common.LogEntries;
+
+public class GetLogEntriesQueryValidatorTests
+{
+    private readonly GetLogEntriesQueryValidator _validator;
+
+    public GetLogEntriesQueryValidatorTests()
+    {
+        _validator = new GetLogEntriesQueryValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Should_Have_Error_When_Page_Is_Less_Than_1(int page)
+    {
+        var query = new GetLogEntriesQuery(Page: page);
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.Page);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Page_Is_Valid()
+    {
+        var query = new GetLogEntriesQuery(Page: 1);
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.Page);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void Should_Have_Error_When_PageSize_Is_Out_Of_Range(int pageSize)
+    {
+        var query = new GetLogEntriesQuery(PageSize: pageSize);
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.PageSize);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_PageSize_Is_Within_Range(int pageSize)
+    {
+        var query = new GetLogEntriesQuery(PageSize: pageSize);
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.PageSize);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/Resume/CreateResumeCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/Resume/CreateResumeCommandValidatorTests.cs
@@ -1,0 +1,56 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.Resume.Commands.CreateResume;
+
+namespace PersonalSite.Application.Tests.Validators.Common.Resume;
+
+public class CreateResumeCommandValidatorTests
+{
+    private readonly CreateResumeCommandValidator _validator;
+
+    public CreateResumeCommandValidatorTests()
+    {
+        _validator = new CreateResumeCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileUrl_Is_Null_Or_Empty()
+    {
+        var command = new CreateResumeCommand("", "filename.pdf", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileUrl);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileUrl_Exceeds_MaxLength()
+    {
+        var longUrl = new string('a', 256);
+        var command = new CreateResumeCommand(longUrl, "filename.pdf", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileUrl);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileName_Is_Null_Or_Empty()
+    {
+        var command = new CreateResumeCommand("fileurl", "", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileName);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Valid_Command()
+    {
+        var command = new CreateResumeCommand("fileurl", "filename.pdf", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.FileUrl);
+        result.ShouldNotHaveValidationErrorFor(x => x.FileName);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/Resume/DeleteResumeCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/Resume/DeleteResumeCommandValidatorTests.cs
@@ -1,0 +1,34 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.Resume.Commands.DeleteResume;
+
+namespace PersonalSite.Application.Tests.Validators.Common.Resume;
+
+public class DeleteResumeCommandValidatorTests
+{
+    private readonly DeleteResumeCommandValidator _validator;
+
+    public DeleteResumeCommandValidatorTests()
+    {
+        _validator = new DeleteResumeCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new DeleteResumeCommand(Guid.Empty);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var command = new DeleteResumeCommand(Guid.NewGuid());
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/Resume/GetResumeByIdQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/Resume/GetResumeByIdQueryValidatorTests.cs
@@ -1,0 +1,35 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.Resume.Queries.GetResumeById;
+
+namespace PersonalSite.Application.Tests.Validators.Common.Resume;
+
+public class GetResumeByIdQueryValidatorTests
+{
+    private readonly GetResumeByIdQueryValidator _validator;
+
+    public GetResumeByIdQueryValidatorTests()
+    {
+        _validator = new GetResumeByIdQueryValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var query = new GetResumeByIdQuery(Guid.Empty);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Resume ID is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var query = new GetResumeByIdQuery(Guid.NewGuid());
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/Resume/GetResumesQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/Resume/GetResumesQueryValidatorTests.cs
@@ -1,0 +1,63 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.Resume.Queries.GetResumes;
+
+namespace PersonalSite.Application.Tests.Validators.Common.Resume;
+
+public class GetResumesQueryValidatorTests
+{
+    private readonly GetResumesQueryValidator _validator;
+
+    public GetResumesQueryValidatorTests()
+    {
+        _validator = new GetResumesQueryValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]    // invalid page number
+    [InlineData(-1)]   // invalid page number
+    public void Should_Have_Error_When_Page_Is_Less_Than_1(int page)
+    {
+        var query = new GetResumesQuery(page);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.Page);
+    }
+
+    [Theory]
+    [InlineData(1)]    // valid page number
+    [InlineData(10)]
+    public void Should_Not_Have_Error_When_Page_Is_Valid(int page)
+    {
+        var query = new GetResumesQuery(page);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Page);
+    }
+
+    [Theory]
+    [InlineData(0)]    // invalid page size
+    [InlineData(101)]  // invalid page size
+    public void Should_Have_Error_When_PageSize_Is_Out_Of_Range(int pageSize)
+    {
+        var query = new GetResumesQuery(1, pageSize);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.PageSize);
+    }
+
+    [Theory]
+    [InlineData(1)]    // valid page size
+    [InlineData(50)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_PageSize_Is_Valid(int pageSize)
+    {
+        var query = new GetResumesQuery(1, pageSize);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.PageSize);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/Resume/UpdateResumeCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/Resume/UpdateResumeCommandValidatorTests.cs
@@ -1,0 +1,70 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.Resume.Commands.UpdateResume;
+
+namespace PersonalSite.Application.Tests.Validators.Common.Resume;
+
+public class UpdateResumeCommandValidatorTests
+{
+    private readonly UpdateResumeCommandValidator _validator;
+
+    public UpdateResumeCommandValidatorTests()
+    {
+        _validator = new UpdateResumeCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new UpdateResumeCommand(Guid.Empty, "http://file.url", "filename.txt", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Resume ID is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileUrl_Is_Empty()
+    {
+        var command = new UpdateResumeCommand(Guid.NewGuid(), string.Empty, "filename.txt", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileUrl)
+            .WithErrorMessage("FileUrl is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileUrl_Too_Long()
+    {
+        var longUrl = new string('a', 256);
+        var command = new UpdateResumeCommand(Guid.NewGuid(), longUrl, "filename.txt", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileUrl)
+            .WithErrorMessage("FileUrl must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FileName_Too_Long()
+    {
+        var longName = new string('a', 256);
+        var command = new UpdateResumeCommand(Guid.NewGuid(), "http://file.url", longName, true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.FileName)
+            .WithErrorMessage("FileName must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Errors_When_Valid_Command()
+    {
+        var command = new UpdateResumeCommand(Guid.NewGuid(), "http://file.url", "filename.txt", true);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/CreateSocialMediaLinkCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/CreateSocialMediaLinkCommandValidatorTests.cs
@@ -1,0 +1,87 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.CreateSocialMediaLink;
+
+namespace PersonalSite.Application.Tests.Validators.Common.SocialMediaLink;
+
+public class CreateSocialMediaLinkCommandValidatorTests
+{
+    private readonly CreateSocialMediaLinkCommandValidator _validator;
+
+    public CreateSocialMediaLinkCommandValidatorTests()
+    {
+        _validator = new CreateSocialMediaLinkCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Platform_Is_Empty()
+    {
+        var command = new CreateSocialMediaLinkCommand("", "https://valid.url", 1, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Platform)
+            .WithErrorMessage("Platform is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Platform_Too_Long()
+    {
+        var platform = new string('a', 51);
+        var command = new CreateSocialMediaLinkCommand(platform, "https://valid.url", 1, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Platform)
+            .WithErrorMessage("Platform must be 50 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Url_Is_Empty()
+    {
+        var command = new CreateSocialMediaLinkCommand("Twitter", "", 1, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Url)
+            .WithErrorMessage("Url is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Url_Too_Long()
+    {
+        var url = "http://" + new string('a', 250) + ".com";
+        var command = new CreateSocialMediaLinkCommand("Twitter", url, 1, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Url)
+            .WithErrorMessage("Url must be 255 characters or fewer.");
+    }
+
+    [Theory]
+    [InlineData("not-a-url", false)]
+    [InlineData("htp:/wrong.com", false)]
+    [InlineData("http://valid.com", true)]
+    [InlineData("https://valid.com", true)]
+    public void BeAValidUrl_Works_Correctly(string url, bool expected)
+    {
+        var validator = new CreateSocialMediaLinkCommandValidator();
+
+        var method = typeof(CreateSocialMediaLinkCommandValidator)
+            .GetMethod("BeAValidUrl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var actual = (bool)method.Invoke(validator, new object[] { url });
+
+        Assert.Equal(expected, actual);
+    }
+
+
+    [Fact]
+    public void Should_Have_Error_When_DisplayOrder_Is_Negative()
+    {
+        var command = new CreateSocialMediaLinkCommand("Twitter", "https://valid.url", -1, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.DisplayOrder)
+            .WithErrorMessage("DisplayOrder cannot be negative.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_All_Fields_Are_Valid()
+    {
+        var command = new CreateSocialMediaLinkCommand("Twitter", "https://valid.url", 0, true);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/DeleteSocialMediaLinkCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/DeleteSocialMediaLinkCommandValidatorTests.cs
@@ -1,0 +1,30 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.DeleteSocialMediaLink;
+
+namespace PersonalSite.Application.Tests.Validators.Common.SocialMediaLink;
+
+public class DeleteSocialMediaLinkCommandValidatorTests
+{
+    private readonly DeleteSocialMediaLinkCommandValidator _validator;
+
+    public DeleteSocialMediaLinkCommandValidatorTests()
+    {
+        _validator = new DeleteSocialMediaLinkCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new DeleteSocialMediaLinkCommand(Guid.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Id);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var command = new DeleteSocialMediaLinkCommand(Guid.NewGuid());
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(c => c.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryValidatorTests.cs
@@ -1,0 +1,33 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Queries.GetSocialMediaLinkById;
+
+namespace PersonalSite.Application.Tests.Validators.Common.SocialMediaLink;
+
+public class GetSocialMediaLinkByIdQueryValidatorTests
+{
+    private readonly GetSocialMediaLinkByIdQueryValidator _validator;
+
+    public GetSocialMediaLinkByIdQueryValidatorTests()
+    {
+        _validator = new GetSocialMediaLinkByIdQueryValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var query = new GetSocialMediaLinkByIdQuery(Guid.Empty);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.Id)
+            .WithErrorMessage("SocialMediaLink ID is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var query = new GetSocialMediaLinkByIdQuery(Guid.NewGuid());
+
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/UpdateSocialMediaLinkCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/UpdateSocialMediaLinkCommandValidatorTests.cs
@@ -1,0 +1,103 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.UpdateSocialMediaLink;
+
+namespace PersonalSite.Application.Tests.Validators.Common.SocialMediaLink;
+
+public class UpdateSocialMediaLinkCommandValidatorTests
+{
+    private readonly UpdateSocialMediaLinkCommandValidator _validator;
+
+    public UpdateSocialMediaLinkCommandValidatorTests()
+    {
+        _validator = new UpdateSocialMediaLinkCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.Empty,
+            "Facebook",
+            "https://valid.url",
+            1,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Id);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Should_Have_Error_When_Url_Is_Null_Or_Empty(string url)
+    {
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.NewGuid(),
+            "Facebook",
+            url,
+            1,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Url);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Url_Is_Invalid()
+    {
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.NewGuid(),
+            "Facebook",
+            "invalid_url",
+            1,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Url);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Url_Too_Long()
+    {
+        var longUrl = new string('a', 256);
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.NewGuid(),
+            "Facebook",
+            longUrl,
+            1,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Url);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_DisplayOrder_Is_Negative()
+    {
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.NewGuid(),
+            "Facebook",
+            "https://valid.url",
+            -1,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.DisplayOrder);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_All_Properties_Are_Valid()
+    {
+        var command = new UpdateSocialMediaLinkCommand(
+            Guid.NewGuid(),
+            "Facebook",
+            "https://valid.url",
+            0,
+            true);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(c => c.Id);
+        result.ShouldNotHaveValidationErrorFor(c => c.Url);
+        result.ShouldNotHaveValidationErrorFor(c => c.DisplayOrder);
+    }
+}


### PR DESCRIPTION
Introduce comprehensive tests for `DeleteLogsCommand`, `GetLogEntriesQuery`, `CreateResumeCommand`, `DeleteResumeCommand`, and `UpdateResumeCommand`. Add mappers test coverage for `LogEntry` and `Resume` entities to ensure consistent mapping logic. Extend `CommonTestDataFactory` with utility methods for creating mock `LogEntry`, `Resume`, and related DTOs.