### PR TITLE
Add comprehensive unit tests for `ContactMessages` feature

### DIFF
--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ContactTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ContactTestDataFactory.cs
@@ -1,0 +1,46 @@
+using PersonalSite.Application.Features.Contact.ContactMessages.Dtos;
+using PersonalSite.Domain.Entities.Contact;
+
+namespace PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+
+public class ContactTestDataFactory
+{
+    public static ContactMessage CreateContactMessage(
+        Guid? id = null,
+        string? name = "John Doe",
+        string? email = "john@example.com",
+        string? subject = "Test Subject",
+        string? message = "Test message content.",
+        string? ipAddress = "127.0.0.1",
+        string? userAgent = "Mozilla/5.0",
+        DateTime? createdAt = null,
+        bool isRead = false)
+    {
+        return new ContactMessage
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = name!,
+            Email = email!,
+            Subject = subject!,
+            Message = message!,
+            IpAddress = ipAddress!,
+            UserAgent = userAgent!,
+            CreatedAt = createdAt ?? DateTime.UtcNow,
+            IsRead = isRead
+        };
+    }
+
+    public static ContactMessageDto MapToDto(ContactMessage entity)
+    {
+        return new ContactMessageDto
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            Email = entity.Email,
+            Subject = entity.Subject,
+            Message = entity.Message,
+            CreatedAt = entity.CreatedAt,
+            IsRead = entity.IsRead
+        };
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
@@ -1,0 +1,6 @@
+namespace PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+
+public class PageTestDataFactory
+{
+    
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/DeleteContactMessagesCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/DeleteContactMessagesCommandHandlerTests.cs
@@ -1,0 +1,96 @@
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.DeleteContactMessages;
+using PersonalSite.Domain.Entities.Contact;
+using PersonalSite.Domain.Interfaces.Repositories.Contact;
+
+namespace PersonalSite.Application.Tests.Handlers.Contact.ContactMessages;
+
+public class DeleteContactMessagesCommandHandlerTests
+{
+    private readonly Mock<IContactMessageRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<DeleteContactMessagesCommandHandler>> _loggerMock = new();
+
+    private DeleteContactMessagesCommandHandler CreateHandler() =>
+        new(_repositoryMock.Object, _unitOfWorkMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenAllMessagesExist()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var messages = new List<ContactMessage>
+        {
+            new() { Id = ids[0], Name = "Test 1" },
+            new() { Id = ids[1], Name = "Test 2" }
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messages);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new DeleteContactMessagesCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _repositoryMock.Verify(r => r.Remove(It.IsAny<ContactMessage>()), Times.Exactly(2));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenSomeMessagesNotFound()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var onlyOneMessage = new List<ContactMessage>
+        {
+            new() { Id = ids[0], Name = "Only found" }
+        };
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(onlyOneMessage);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new DeleteContactMessagesCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Some messages were not found.");
+        _repositoryMock.Verify(r => r.Remove(It.IsAny<ContactMessage>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid() };
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB error"));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new DeleteContactMessagesCommand(ids), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Failed to delete messages.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) =>
+                    state.ToString() != null &&
+                    state.ToString()!.Contains("Error deleting contact messages.")
+                ),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once
+        );
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessageByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessageByIdQueryHandlerTests.cs
@@ -1,0 +1,95 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Contact.ContactMessages.Dtos;
+using PersonalSite.Application.Features.Contact.ContactMessages.Queries.GetContactMessageById;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Contact;
+using PersonalSite.Domain.Interfaces.Repositories.Contact;
+
+namespace PersonalSite.Application.Tests.Handlers.Contact.ContactMessages;
+
+public class GetContactMessageByIdQueryHandlerTests
+{
+    private readonly Mock<IContactMessageRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetContactMessageByIdQueryHandler>> _loggerMock = new();
+    private readonly Mock<IMapper<ContactMessage, ContactMessageDto>> _mapperMock = new();
+
+    private GetContactMessageByIdQueryHandler CreateHandler() =>
+        new(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenContactMessageExists()
+    {
+        // Arrange
+        var entity = ContactTestDataFactory.CreateContactMessage();
+        var dto = ContactTestDataFactory.MapToDto(entity);
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+        _mapperMock.Setup(m => m.MapToDto(entity)).Returns(dto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessageByIdQuery(entity.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dto);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenContactMessageNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContactMessage?)null);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Contact message not found.");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Contact message not found")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogErrorAndReturnFailure_OnException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("db error"));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error getting contact message by id.");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Error getting contact message by id")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessagesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessagesQueryHandlerTests.cs
@@ -1,0 +1,89 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Contact.ContactMessages.Dtos;
+using PersonalSite.Application.Features.Contact.ContactMessages.Queries.GetContactMessages;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Common.Results;
+using PersonalSite.Domain.Entities.Contact;
+using PersonalSite.Domain.Interfaces.Repositories.Contact;
+
+namespace PersonalSite.Application.Tests.Handlers.Contact.ContactMessages;
+
+public class GetContactMessagesQueryHandlerTests
+{
+    private readonly Mock<IContactMessageRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetContactMessagesQueryHandler>> _loggerMock = new();
+    private readonly Mock<IMapper<ContactMessage, ContactMessageDto>> _mapperMock = new();
+
+    private GetContactMessagesQueryHandler CreateHandler() =>
+        new(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenMessagesExist()
+    {
+        // Arrange
+        var messages = new List<ContactMessage>
+        {
+            ContactTestDataFactory.CreateContactMessage(name:"John Doe"),
+            ContactTestDataFactory.CreateContactMessage(name:"Jane Smith")
+        };
+
+        var pagedResult = PaginatedResult<ContactMessage>.Success(messages, 1, 10, 2);
+        var dtoList = new List<ContactMessageDto>
+        {
+            ContactTestDataFactory.MapToDto(messages[0]),
+            ContactTestDataFactory.MapToDto(messages[1])       
+        };
+
+        _repositoryMock.Setup(r => r.GetFilteredAsync(1, 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+        _mapperMock.Setup(m => m.MapToDtoList(messages))
+            .Returns(dtoList);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessagesQuery(1, 10), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dtoList);
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(10);
+        result.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenRepositoryReturnsFailure()
+    {
+        // Arrange
+        var pagedResult = PaginatedResult<ContactMessage>.Failure("Not found");
+        _repositoryMock.Setup(r => r.GetFilteredAsync(1, 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessagesQuery(1, 10), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Contact messages not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenExceptionIsThrown()
+    {
+        // Arrange
+        _repositoryMock.Setup(r => r.GetFilteredAsync(1, 10, null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database failure"));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetContactMessagesQuery(1, 10), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error getting contact messages.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/SendContactMessageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/SendContactMessageCommandHandlerTests.cs
@@ -1,0 +1,77 @@
+using MediatR;
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.SendContactMessage;
+using PersonalSite.Application.Features.Contact.ContactMessages.Events.ContactMessageCreated;
+using PersonalSite.Domain.Entities.Contact;
+using PersonalSite.Domain.Interfaces.Repositories.Contact;
+
+namespace PersonalSite.Application.Tests.Handlers.Contact.ContactMessages;
+
+public class SendContactMessageCommandHandlerTests
+{
+    private readonly Mock<IContactMessageRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly Mock<ILogger<SendContactMessageCommandHandler>> _loggerMock = new();
+
+    private SendContactMessageCommandHandler CreateHandler() =>
+        new(_repositoryMock.Object, _unitOfWorkMock.Object, _mediatorMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_AndPublishEvent_WhenValidRequest()
+    {
+        // Arrange
+        var command = new SendContactMessageCommand("John", "john@example.com", "Hello", "Test message")
+        {
+            IpAddress = "127.0.0.1",
+            UserAgent = "TestAgent"
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.AddAsync(It.Is<ContactMessage>(m =>
+            m.Name == "John" &&
+            m.Email == "john@example.com" &&
+            m.Subject == "Hello" &&
+            m.Message == "Test message" &&
+            m.IpAddress == "127.0.0.1" &&
+            m.UserAgent == "TestAgent" &&
+            !m.IsRead
+        ), It.IsAny<CancellationToken>()), Times.Once);
+
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Publish(It.IsAny<ContactMessageCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var command = new SendContactMessageCommand("John", "john@example.com", "Hello", "Test message");
+        _repositoryMock.Setup(r => r.AddAsync(It.IsAny<ContactMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB error"));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error creating contact message.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating contact message.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandHandlerTests.cs
@@ -1,0 +1,100 @@
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.UpdateContactMessagesReadStatus;
+using PersonalSite.Domain.Entities.Contact;
+using PersonalSite.Domain.Interfaces.Repositories.Contact;
+
+namespace PersonalSite.Application.Tests.Handlers.Contact.ContactMessages;
+
+public class UpdateContactMessagesReadStatusCommandHandlerTests
+{
+    private readonly Mock<IContactMessageRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<UpdateContactMessagesReadStatusCommandHandler>> _loggerMock;
+    private readonly UpdateContactMessagesReadStatusCommandHandler _handler;
+
+    public UpdateContactMessagesReadStatusCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<IContactMessageRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<UpdateContactMessagesReadStatusCommandHandler>>();
+        _handler = new UpdateContactMessagesReadStatusCommandHandler(
+            _repositoryMock.Object, 
+            _unitOfWorkMock.Object, 
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateAllMessages_WhenAllFound()
+    {
+        // Arrange
+        var messageIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var messages = messageIds.Select(id => new ContactMessage { Id = id, IsRead = false }).ToList();
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(messageIds, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messages);
+
+        var command = new UpdateContactMessagesReadStatusCommand(messageIds, true);
+
+        var handler = new UpdateContactMessagesReadStatusCommandHandler(_repositoryMock.Object, _unitOfWorkMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        foreach (var msg in messages)
+            msg.IsRead.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<ContactMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(messages.Count));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenSomeMessagesNotFound()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var messages = new List<ContactMessage> { new ContactMessage { Id = ids[0], IsRead = false } }; // Only 1 found
+        var command = new UpdateContactMessagesReadStatusCommand(ids, true);
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messages);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Some messages were not found.");
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<ContactMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogErrorAndReturnFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var ids = new List<Guid> { Guid.NewGuid() };
+        var command = new UpdateContactMessagesReadStatusCommand(ids, true);
+
+        _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB error"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Failed to update read status.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) =>
+                    state.ToString()!.Contains("Error updating read status of contact messages.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Contact/ContactMessages/ContactMessageMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Contact/ContactMessages/ContactMessageMapperTests.cs
@@ -1,0 +1,76 @@
+using PersonalSite.Application.Features.Contact.ContactMessages.Mappers;
+using PersonalSite.Domain.Entities.Contact;
+
+namespace PersonalSite.Application.Tests.Mappers.Contact.ContactMessages;
+
+public class ContactMessageMapperTests
+{
+    private readonly ContactMessageMapper _mapper = new();
+
+    [Fact]
+    public void MapToDto_Should_Map_All_Fields_Correctly()
+    {
+        // Arrange
+        var entity = new ContactMessage
+        {
+            Id = Guid.NewGuid(),
+            Name = "John Doe",
+            Email = "john@example.com",
+            Subject = "Subject here",
+            Message = "Message content",
+            CreatedAt = DateTime.UtcNow,
+            IsRead = true
+        };
+
+        // Act
+        var dto = _mapper.MapToDto(entity);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(entity.Id);
+        dto.Name.Should().Be(entity.Name);
+        dto.Email.Should().Be(entity.Email);
+        dto.Subject.Should().Be(entity.Subject);
+        dto.Message.Should().Be(entity.Message);
+        dto.CreatedAt.Should().Be(entity.CreatedAt);
+        dto.IsRead.Should().Be(entity.IsRead);
+    }
+
+    [Fact]
+    public void MapToDtoList_Should_Map_All_Entities_To_Dtos()
+    {
+        // Arrange
+        var entities = new List<ContactMessage>
+        {
+            new ContactMessage
+            {
+                Id = Guid.NewGuid(),
+                Name = "User 1",
+                Email = "user1@example.com",
+                Subject = "Subj 1",
+                Message = "Message 1",
+                CreatedAt = DateTime.UtcNow,
+                IsRead = false
+            },
+            new ContactMessage
+            {
+                Id = Guid.NewGuid(),
+                Name = "User 2",
+                Email = "user2@example.com",
+                Subject = "Subj 2",
+                Message = "Message 2",
+                CreatedAt = DateTime.UtcNow,
+                IsRead = true
+            }
+        };
+
+        // Act
+        var dtos = _mapper.MapToDtoList(entities);
+
+        // Assert
+        dtos.Should().HaveCount(entities.Count);
+        dtos.Select(d => d.Id).Should().BeEquivalentTo(entities.Select(e => e.Id));
+        dtos[0].Name.Should().Be(entities[0].Name);
+        dtos[1].Name.Should().Be(entities[1].Name);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/DeleteContactMessagesCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/DeleteContactMessagesCommandValidatorTests.cs
@@ -1,0 +1,31 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.DeleteContactMessages;
+
+namespace PersonalSite.Application.Tests.Validators.Contact.ContactMessages;
+
+public class DeleteContactMessagesCommandValidatorTests
+{
+    private readonly DeleteContactMessagesCommandValidator _validator;
+
+    public DeleteContactMessagesCommandValidatorTests()
+    {
+        _validator = new DeleteContactMessagesCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Ids_Is_Empty()
+    {
+        var command = new DeleteContactMessagesCommand(new List<Guid>());
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Ids)
+            .WithErrorMessage("At least one message Id must be provided.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Ids_Has_Values()
+    {
+        var command = new DeleteContactMessagesCommand(new List<Guid> { Guid.NewGuid() });
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(c => c.Ids);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/GetContactMessageByIdQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/GetContactMessageByIdQueryValidatorTests.cs
@@ -1,0 +1,31 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Contact.ContactMessages.Queries.GetContactMessageById;
+
+namespace PersonalSite.Application.Tests.Validators.Contact.ContactMessages;
+
+public class GetContactMessageByIdQueryValidatorTests
+{
+    private readonly GetContactMessageByIdQueryValidator _validator;
+
+    public GetContactMessageByIdQueryValidatorTests()
+    {
+        _validator = new GetContactMessageByIdQueryValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var query = new GetContactMessageByIdQuery(Guid.Empty);
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.Id)
+            .WithErrorMessage("Id is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Not_Empty()
+    {
+        var query = new GetContactMessageByIdQuery(Guid.NewGuid());
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/GetContactMessagesQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/GetContactMessagesQueryValidatorTests.cs
@@ -1,0 +1,60 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Contact.ContactMessages.Queries.GetContactMessages;
+
+namespace PersonalSite.Application.Tests.Validators.Contact.ContactMessages;
+
+public class GetContactMessagesQueryValidatorTests
+{
+    private readonly GetContactMessagesQueryValidator _validator;
+
+    public GetContactMessagesQueryValidatorTests()
+    {
+        _validator = new GetContactMessagesQueryValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Should_Have_Error_When_Page_Is_Less_Than_1(int invalidPage)
+    {
+        var query = new GetContactMessagesQuery(Page: invalidPage, PageSize: 10);
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.Page)
+            .WithErrorMessage("Page number must be greater than zero.");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_Page_Is_Valid(int validPage)
+    {
+        var query = new GetContactMessagesQuery(Page: validPage, PageSize: 10);
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.Page);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    [InlineData(101)]
+    [InlineData(200)]
+    public void Should_Have_Error_When_PageSize_Is_Out_Of_Range(int invalidPageSize)
+    {
+        var query = new GetContactMessagesQuery(Page: 1, PageSize: invalidPageSize);
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(q => q.PageSize)
+            .WithErrorMessage("Page size must be between 1 and 100.");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_PageSize_Is_Valid(int validPageSize)
+    {
+        var query = new GetContactMessagesQuery(Page: 1, PageSize: validPageSize);
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(q => q.PageSize);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/SendContactMessageCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/SendContactMessageCommandValidatorTests.cs
@@ -1,0 +1,118 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.SendContactMessage;
+
+namespace PersonalSite.Application.Tests.Validators.Contact.ContactMessages;
+
+public class SendContactMessageCommandValidatorTests
+{
+    private readonly SendContactMessageCommandValidator _validator;
+
+    public SendContactMessageCommandValidatorTests()
+    {
+        _validator = new SendContactMessageCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Name_Is_Empty()
+    {
+        var command = new SendContactMessageCommand("", "test@example.com", "Subject", "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Name)
+            .WithErrorMessage("Name is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Name_Too_Long()
+    {
+        var longName = new string('a', 101);
+        var command = new SendContactMessageCommand(longName, "test@example.com", "Subject", "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Name)
+            .WithErrorMessage("Name must be 100 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Empty()
+    {
+        var command = new SendContactMessageCommand("Name", "", "Subject", "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Email)
+            .WithErrorMessage("Email is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Too_Long()
+    {
+        var longEmail = new string('a', 140) + "@example.com";
+        var command = new SendContactMessageCommand("Name", longEmail, "Subject", "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Email)
+            .WithErrorMessage("Email must be 150 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Invalid()
+    {
+        var command = new SendContactMessageCommand("Name", "invalid-email", "Subject", "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Email)
+            .WithErrorMessage("Email must be a valid email address.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Subject_Too_Long()
+    {
+        var longSubject = new string('a', 201);
+        var command = new SendContactMessageCommand("Name", "test@example.com", longSubject, "Message");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Subject)
+            .WithErrorMessage("Subject must be 200 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Message_Is_Empty()
+    {
+        var command = new SendContactMessageCommand("Name", "test@example.com", "Subject", "");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Message)
+            .WithErrorMessage("Message is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_IpAddress_Too_Long()
+    {
+        var longIp = new string('1', 51);
+        var command = new SendContactMessageCommand("Name", "test@example.com", "Subject", "Message")
+        {
+            IpAddress = longIp
+        };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.IpAddress)
+            .WithErrorMessage("IpAddress must be 50 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_UserAgent_Too_Long()
+    {
+        var longAgent = new string('a', 256);
+        var command = new SendContactMessageCommand("Name", "test@example.com", "Subject", "Message")
+        {
+            UserAgent = longAgent
+        };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.UserAgent)
+            .WithErrorMessage("UserAgent must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_All_Fields_Are_Valid()
+    {
+        var command = new SendContactMessageCommand("Name", "test@example.com", "Subject", "Message")
+        {
+            IpAddress = "127.0.0.1",
+            UserAgent = "UnitTestAgent"
+        };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandValidatorTests.cs
@@ -1,0 +1,31 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.UpdateContactMessagesReadStatus;
+
+namespace PersonalSite.Application.Tests.Validators.Contact.ContactMessages;
+
+public class UpdateContactMessagesReadStatusCommandValidatorTests
+{
+    private readonly UpdateContactMessagesReadStatusCommandValidator _validator;
+
+    public UpdateContactMessagesReadStatusCommandValidatorTests()
+    {
+        _validator = new UpdateContactMessagesReadStatusCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Ids_Is_Empty()
+    {
+        var command = new UpdateContactMessagesReadStatusCommand(new List<Guid>(), true);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Ids)
+            .WithErrorMessage("At least one message Id must be provided.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Ids_Is_Not_Empty()
+    {
+        var command = new UpdateContactMessagesReadStatusCommand([Guid.NewGuid()], true);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(c => c.Ids);
+    }
+}


### PR DESCRIPTION
Introduce unit test coverage for all handlers, validators, mappers, and test data factories associated with `ContactMessages`. Includes tests for commands like `DeleteContactMessages`, `SendContactMessage`, `UpdateContactMessagesReadStatus`, as well as queries like `GetContactMessages` and `GetContactMessageById`.