### PR TITLE
Add comprehensive unit tests for `Pages` feature

### DIFF
--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
@@ -1,6 +1,91 @@
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Domain.Entities.Pages;
+using PersonalSite.Domain.Entities.Translations;
+
 namespace PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 
 public class PageTestDataFactory
 {
-    
+    public static Page CreatePage(Guid? id = null, string key = "page-key")
+    {
+        var pageId = id ?? Guid.NewGuid();
+        var language1 = CommonTestDataFactory.CreateLanguage();
+        var language2 = CommonTestDataFactory.CreateLanguage("pl");
+        var page = new Page
+        {
+            Id = pageId,
+            Key = key,
+            Translations = [
+                new PageTranslation
+                {
+                    Id = Guid.NewGuid(),
+                    PageId = pageId,
+                    LanguageId = language1.Id,
+                    Language = language1,
+                    Title = "Title 1",
+                    Description = "Description 1",
+                    MetaTitle = "MetaTitle 1",
+                    MetaDescription = "MetaDescription 1",
+                    OgImage = "ogimage1.png"
+                },
+                new PageTranslation
+                {
+                    Id = Guid.NewGuid(),
+                    PageId = pageId,
+                    LanguageId = language2.Id,
+                    Language = language2,
+                    Title = "Title 2",
+                    Description = "Description 2",
+                    MetaTitle = "MetaTitle 2",
+                    MetaDescription = "MetaDescription 2",
+                    OgImage = "ogimage2.png"
+                }
+            ]
+        };
+
+        return page;
+    }
+
+    public static PageDto MapToDto(Page page)
+    {
+        return new PageDto
+        {
+            Id = page.Id,
+            Key = page.Key,
+            Data = page.Translations.First().Data,
+            Title = page.Translations.First().Title,
+            Description = page.Translations.First().Description,
+            MetaTitle = page.Translations.First().MetaTitle,
+            MetaDescription = page.Translations.First().MetaDescription,
+            OgImage = page.Translations.First().OgImage
+        };
+    }
+
+    public static PageAdminDto MapToAdminDto(Page page)
+    {
+        var dto = new PageAdminDto
+        {
+            Id = page.Id,
+            Key = page.Key,
+            Translations = []
+        };
+
+        foreach (var t in page.Translations)
+        {
+            dto.Translations.Add(new PageTranslationDto
+            {
+                Id = t.Id,
+                LanguageCode = t.Language.Code,
+                PageId = t.PageId,
+                Title = t.Title,
+                Data = t.Data,
+                Description = t.Description,
+                MetaTitle = t.MetaTitle,
+                MetaDescription = t.MetaDescription,
+                OgImage = t.OgImage
+            });
+        }
+
+        return dto;
+    }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/CreatePageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/CreatePageCommandHandlerTests.cs
@@ -1,0 +1,136 @@
+using PersonalSite.Application.Features.Pages.Page.Commands.CreatePage;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+using PersonalSite.Domain.Interfaces.Repositories.Translations;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class CreatePageCommandHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock = new();
+    private readonly Mock<ILanguageRepository> _languageRepositoryMock = new();
+    private readonly Mock<IPageTranslationRepository> _translationRepositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<CreatePageCommandHandler>> _loggerMock = new();
+
+    private CreatePageCommandHandler CreateHandler() => new(
+        _pageRepositoryMock.Object,
+        _languageRepositoryMock.Object,
+        _translationRepositoryMock.Object,
+        _unitOfWorkMock.Object,
+        _loggerMock.Object
+    );
+
+    private static CreatePageCommand CreateCommand(string key = "about") => new(
+        key,
+        new List<PageTranslationDto>
+        {
+            new()
+            {
+                LanguageCode = "en",
+                Title = "About",
+                Description = "About page",
+                MetaTitle = "About Meta",
+                MetaDescription = "About Meta Description",
+                OgImage = "og-about.png",
+                Data = new Dictionary<string, string> { ["content"] = "Welcome!" }
+            }
+        }
+    );
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenKeyIsNotAvailable()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _pageRepositoryMock.Setup(r => r.IsKeyAvailableAsync(command.Key, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Key is already in use.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenLanguageNotFound()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _pageRepositoryMock.Setup(r => r.IsKeyAvailableAsync(command.Key, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(r => r.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Language?)null); // Language not found
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Language en not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenPageCreated()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var language = new Language { Id = Guid.NewGuid(), Code = "en", Name = "English" };
+
+        _pageRepositoryMock.Setup(r => r.IsKeyAvailableAsync(command.Key, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(r => r.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(language);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBe(Guid.Empty);
+
+        _pageRepositoryMock.Verify(r => r.AddAsync(It.IsAny<Domain.Entities.Pages.Page>(), It.IsAny<CancellationToken>()), Times.Once);
+        _translationRepositoryMock.Verify(r => r.AddAsync(It.IsAny<PageTranslation>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _pageRepositoryMock.Setup(r => r.IsKeyAvailableAsync(command.Key, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Unexpected"));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error creating about page.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating about page.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/DeletePageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/DeletePageCommandHandlerTests.cs
@@ -1,0 +1,110 @@
+using PersonalSite.Application.Features.Pages.Page.Commands.DeletePage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class DeletePageCommandHandlerTests
+    {
+        private readonly Mock<IPageRepository> _repositoryMock;
+        private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+        private readonly Mock<ILogger<DeletePageCommandHandler>> _loggerMock;
+        private readonly DeletePageCommandHandler _handler;
+
+        public DeletePageCommandHandlerTests()
+        {
+            _repositoryMock = new Mock<IPageRepository>();
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _loggerMock = new Mock<ILogger<DeletePageCommandHandler>>();
+
+            _handler = new DeletePageCommandHandler(
+                _repositoryMock.Object,
+                _unitOfWorkMock.Object,
+                _loggerMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task Handle_DeletesExistingPage_ReturnsSuccess()
+        {
+            // Arrange
+            var page = PageTestDataFactory.CreatePage();
+            var command = new DeletePageCommand(page.Id);
+
+            _repositoryMock
+                .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page);
+
+            _repositoryMock
+                .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _unitOfWorkMock
+                .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            page.IsDeleted.Should().BeTrue();
+
+            _repositoryMock.Verify(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()), Times.Once);
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_PageNotFound_ReturnsFailure()
+        {
+            // Arrange
+            var command = new DeletePageCommand(Guid.NewGuid());
+
+            _repositoryMock
+                .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("Page not found.");
+
+            _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Pages.Page>(), It.IsAny<CancellationToken>()), Times.Never);
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
+        {
+            // Arrange
+            var page = PageTestDataFactory.CreatePage();
+            var command = new DeletePageCommand(page.Id);
+
+            _repositoryMock
+                .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page);
+
+            _repositoryMock
+                .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Database failure"));
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("Error deleting page.");
+
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error deleting page.") == true),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once
+            );
+        }
+    }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetAboutPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetAboutPageQueryHandlerTests.cs
@@ -1,0 +1,189 @@
+using PersonalSite.Application.Common.Localization;
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetAboutPage;
+using PersonalSite.Application.Features.Skills.LearningSkills.Dtos;
+using PersonalSite.Application.Features.Skills.UserSkills.Dtos;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+using PersonalSite.Domain.Interfaces.Repositories.Skills;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetAboutPageQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock;
+    private readonly Mock<IUserSkillRepository> _userSkillRepositoryMock;
+    private readonly Mock<ILearningSkillRepository> _learningSkillRepositoryMock;
+    private readonly Mock<ILogger<GetAboutPageQueryHandler>> _loggerMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
+    private readonly Mock<ITranslatableMapper<LearningSkill, LearningSkillDto>> _learningSkillMapperMock;
+    private readonly Mock<ITranslatableMapper<UserSkill, UserSkillDto>> _userSkillMapperMock;
+    private readonly LanguageContext _languageContext;
+    private readonly GetAboutPageQueryHandler _handler;
+
+    public GetAboutPageQueryHandlerTests()
+    {
+        _pageRepositoryMock = new Mock<IPageRepository>();
+        _userSkillRepositoryMock = new Mock<IUserSkillRepository>();
+        _learningSkillRepositoryMock = new Mock<ILearningSkillRepository>();
+        _loggerMock = new Mock<ILogger<GetAboutPageQueryHandler>>();
+        _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
+        _learningSkillMapperMock = new Mock<ITranslatableMapper<LearningSkill, LearningSkillDto>>();
+        _userSkillMapperMock = new Mock<ITranslatableMapper<UserSkill, UserSkillDto>>();
+
+        _languageContext = new LanguageContext { LanguageCode = "en" };
+
+        _handler = new GetAboutPageQueryHandler(
+            _languageContext,
+            _pageRepositoryMock.Object,
+            _userSkillRepositoryMock.Object,
+            _learningSkillRepositoryMock.Object,
+            _loggerMock.Object,
+            _pageMapperMock.Object,
+            _learningSkillMapperMock.Object,
+            _userSkillMapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLanguageContext_ReturnsFailure()
+    {
+        // Arrange
+        _languageContext.LanguageCode = null!;
+        var query = new GetAboutPageQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid language context.");
+    }
+
+    [Fact]
+    public async Task Handle_PageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("about", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetAboutPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Home page not found.");
+    }
+
+    [Fact]
+    public async Task Handle_NoUserSkillsOrLearningSkills_LogsWarningAndReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "About" };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("about", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en"))
+            .Returns(pageDto);
+
+        _userSkillRepositoryMock.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserSkill>());
+
+        _userSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<UserSkill>>(), "en"))
+            .Returns(new List<UserSkillDto>());
+
+        _learningSkillRepositoryMock.Setup(r => r.GetAllOrderedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LearningSkill>());
+
+        _learningSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<LearningSkill>>(), "en"))
+            .Returns(new List<LearningSkillDto>());
+
+        // Act
+        var result = await _handler.Handle(new GetAboutPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.UserSkills.Should().BeEmpty();
+        result.Value.LearningSkills.Should().BeEmpty();
+
+        // Verify warning logs for no skills
+        _loggerMock.Verify(l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("No skills found.")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(2)); // Once for user skills and once for learning skills
+    }
+
+    [Fact]
+    public async Task Handle_AllDataPresent_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "About" };
+
+        var userSkill = new UserSkill { Id = Guid.NewGuid() };
+        var userSkillDto = new UserSkillDto { Id = userSkill.Id };
+
+        var learningSkill = new LearningSkill { Id = Guid.NewGuid() };
+        var learningSkillDto = new LearningSkillDto { Id = learningSkill.Id };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("about", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en"))
+            .Returns(pageDto);
+
+        _userSkillRepositoryMock.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserSkill> { userSkill });
+
+        _userSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<UserSkill>>(), "en"))
+            .Returns(new List<UserSkillDto> { userSkillDto });
+
+        _learningSkillRepositoryMock.Setup(r => r.GetAllOrderedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LearningSkill> { learningSkill });
+
+        _learningSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<LearningSkill>>(), "en"))
+            .Returns(new List<LearningSkillDto> { learningSkillDto });
+
+        // Act
+        var result = await _handler.Handle(new GetAboutPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.UserSkills.Should().ContainSingle().Which.Id.Should().Be(userSkill.Id);
+        result.Value.LearningSkills.Should().ContainSingle().Which.Id.Should().Be(learningSkill.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB failure"));
+
+        // Act
+        var result = await _handler.Handle(new GetAboutPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while getting About page data.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetBlogPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetBlogPageQueryHandlerTests.cs
@@ -1,0 +1,155 @@
+using PersonalSite.Application.Common.Localization;
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Blogs.Blog.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetBlogPage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Blog;
+using PersonalSite.Domain.Interfaces.Repositories.Blog;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetBlogPageQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock;
+    private readonly Mock<IBlogPostRepository> _blogPostRepositoryMock;
+    private readonly Mock<ILogger<GetBlogPageQueryHandler>> _loggerMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
+    private readonly Mock<ITranslatableMapper<BlogPost, BlogPostDto>> _blogPostMapperMock;
+    private readonly LanguageContext _languageContext;
+    private readonly GetBlogPageQueryHandler _handler;
+
+    public GetBlogPageQueryHandlerTests()
+    {
+        _pageRepositoryMock = new Mock<IPageRepository>();
+        _blogPostRepositoryMock = new Mock<IBlogPostRepository>();
+        _loggerMock = new Mock<ILogger<GetBlogPageQueryHandler>>();
+        _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
+        _blogPostMapperMock = new Mock<ITranslatableMapper<BlogPost, BlogPostDto>>();
+
+        _languageContext = new LanguageContext { LanguageCode = "en" };
+
+        _handler = new GetBlogPageQueryHandler(
+            _languageContext,
+            _pageRepositoryMock.Object,
+            _blogPostRepositoryMock.Object,
+            _loggerMock.Object,
+            _pageMapperMock.Object,
+            _blogPostMapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLanguageContext_ReturnsFailure()
+    {
+        // Arrange
+        _languageContext.LanguageCode = null!;
+        var query = new GetBlogPageQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid language context.");
+    }
+
+    [Fact]
+    public async Task Handle_BlogPageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("blog", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetBlogPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Blog page not found.");
+    }
+
+    [Fact]
+    public async Task Handle_NoBlogPostsFound_ReturnsSuccessWithEmptyList()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "Blog Page" };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("blog", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en"))
+            .Returns(pageDto);
+
+        _blogPostRepositoryMock.Setup(r => r.GetPublishedPostsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BlogPost>());
+
+        _blogPostMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<BlogPost>>(), "en"))
+            .Returns(new List<BlogPostDto>());
+
+        // Act
+        var result = await _handler.Handle(new GetBlogPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.BlogPosts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_BlogPageAndPostsFound_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "Blog Page" };
+
+        var blogPost = new BlogPost { Id = Guid.NewGuid() };
+        var blogPostDto = new BlogPostDto { Id = blogPost.Id };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("blog", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en"))
+            .Returns(pageDto);
+
+        _blogPostRepositoryMock.Setup(r => r.GetPublishedPostsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BlogPost> { blogPost });
+
+        _blogPostMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<BlogPost>>(), "en"))
+            .Returns(new List<BlogPostDto> { blogPostDto });
+
+        // Act
+        var result = await _handler.Handle(new GetBlogPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.BlogPosts.Should().ContainSingle();
+        result.Value.BlogPosts[0].Id.Should().Be(blogPost.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB error"));
+
+        // Act
+        var result = await _handler.Handle(new GetBlogPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving blog page data.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetContactPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetContactPageQueryHandlerTests.cs
@@ -1,0 +1,114 @@
+using PersonalSite.Application.Common.Localization;
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetContactPage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetContactPageQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock;
+    private readonly Mock<ILogger<GetContactPageQueryHandler>> _loggerMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
+    private readonly LanguageContext _languageContext;
+    private readonly GetContactPageQueryHandler _handler;
+
+    public GetContactPageQueryHandlerTests()
+    {
+        _pageRepositoryMock = new Mock<IPageRepository>();
+        _loggerMock = new Mock<ILogger<GetContactPageQueryHandler>>();
+        _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
+
+        _languageContext = new LanguageContext { LanguageCode = "en" };
+
+        _handler = new GetContactPageQueryHandler(
+            _languageContext,
+            _pageRepositoryMock.Object,
+            null!, // blogPostRepository is not used in your handler; pass null or mock if needed
+            _loggerMock.Object,
+            _pageMapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLanguageContext_ReturnsFailure()
+    {
+        // Arrange
+        _languageContext.LanguageCode = null!;
+        var query = new GetContactPageQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid language context.");
+    }
+
+    [Fact]
+    public async Task Handle_ContactPageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("contacts", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetContactPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Contact page not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ContactPageFound_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto
+        {
+            Title = "Contact Title",
+            Description = "Contact Description"
+        };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("contacts", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en"))
+            .Returns(pageDto);
+
+        // Act
+        var result = await _handler.Handle(new GetContactPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.PageData.Should().Be(pageDto);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB failure"));
+
+        // Act
+        var result = await _handler.Handle(new GetContactPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving contact page data.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetHomePageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetHomePageQueryHandlerTests.cs
@@ -1,0 +1,171 @@
+using PersonalSite.Application.Common.Localization;
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetHomePage;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Features.Skills.UserSkills.Dtos;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Projects;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+using PersonalSite.Domain.Interfaces.Repositories.Skills;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetHomePageQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock;
+    private readonly Mock<IUserSkillRepository> _userSkillRepositoryMock;
+    private readonly Mock<IProjectRepository> _projectRepositoryMock;
+    private readonly Mock<ILogger<GetHomePageQueryHandler>> _loggerMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
+    private readonly Mock<ITranslatableMapper<UserSkill, UserSkillDto>> _userSkillMapperMock;
+    private readonly Mock<ITranslatableMapper<Project, ProjectDto>> _projectMapperMock;
+    private readonly LanguageContext _languageContext;
+    private readonly GetHomePageQueryHandler _handler;
+
+    public GetHomePageQueryHandlerTests()
+    {
+        _pageRepositoryMock = new Mock<IPageRepository>();
+        _userSkillRepositoryMock = new Mock<IUserSkillRepository>();
+        _projectRepositoryMock = new Mock<IProjectRepository>();
+        _loggerMock = new Mock<ILogger<GetHomePageQueryHandler>>();
+        _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
+        _userSkillMapperMock = new Mock<ITranslatableMapper<UserSkill, UserSkillDto>>();
+        _projectMapperMock = new Mock<ITranslatableMapper<Project, ProjectDto>>();
+
+        _languageContext = new LanguageContext { LanguageCode = "en" };
+
+        _handler = new GetHomePageQueryHandler(
+            _languageContext,
+            _pageRepositoryMock.Object,
+            _userSkillRepositoryMock.Object,
+            _projectRepositoryMock.Object,
+            _loggerMock.Object,
+            _pageMapperMock.Object,
+            _userSkillMapperMock.Object,
+            _projectMapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLanguageContext_ReturnsFailure()
+    {
+        // Arrange
+        _languageContext.LanguageCode = null!;
+        var query = new GetHomePageQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid language context.");
+    }
+
+    [Fact]
+    public async Task Handle_PageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("home", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetHomePageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("About page not found.");
+    }
+
+    [Fact]
+    public async Task Handle_PageFound_NoSkills_NoProject_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "Home" };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("home", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en")).Returns(pageDto);
+
+        _userSkillRepositoryMock.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserSkill>());
+        _userSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<UserSkill>>(), "en"))
+            .Returns(new List<UserSkillDto>());
+
+        _projectRepositoryMock.Setup(r => r.GetLastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Project?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetHomePageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.UserSkills.Should().BeEmpty();
+        result.Value.LastProject.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AllDataPresent_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = new PageDto { Title = "Home" };
+
+        var userSkill = new UserSkill { Id = Guid.NewGuid() };
+        var userSkillDto = new UserSkillDto { Id = userSkill.Id };
+
+        var project = new Project { Id = Guid.NewGuid() };
+        var projectDto = new ProjectDto { Id = project.Id };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("home", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+        _pageMapperMock.Setup(m => m.MapToDto(page, "en")).Returns(pageDto);
+
+        _userSkillRepositoryMock.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([userSkill]);
+        _userSkillMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<UserSkill>>(), "en"))
+            .Returns([userSkillDto]);
+
+        _projectRepositoryMock.Setup(r => r.GetLastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(project);
+        _projectMapperMock.Setup(m => m.MapToDto(project, "en")).Returns(projectDto);
+
+        // Act
+        var result = await _handler.Handle(new GetHomePageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.UserSkills.Should().ContainSingle();
+        result.Value.LastProject.Should().Be(projectDto);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("home", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB crash"));
+
+        // Act
+        var result = await _handler.Handle(new GetHomePageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving home page data.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+            ),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPageByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPageByIdQueryHandlerTests.cs
@@ -1,0 +1,99 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetPageById;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetPageByIdQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetPageByIdQueryHandler>> _loggerMock = new();
+    private readonly Mock<IAdminMapper<Domain.Entities.Pages.Page, PageAdminDto>> _mapperMock = new();
+
+    private GetPageByIdQueryHandler CreateHandler()
+    {
+        return new GetPageByIdQueryHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenPageNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _repositoryMock.Setup(r => r.GetWithTranslationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page)null);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetPageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Page not found.");
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Page not found")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenPageFound()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var dto = PageTestDataFactory.MapToAdminDto(page);
+
+        _repositoryMock.Setup(r => r.GetWithTranslationByIdAsync(page.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _mapperMock.Setup(m => m.MapToAdminDto(page))
+            .Returns(dto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetPageByIdQuery(page.Id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dto);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogErrorAndReturnFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var exception = new Exception("DB error");
+        _repositoryMock.Setup(r => r.GetWithTranslationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetPageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error getting page by id.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error getting page by id.")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPagesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPagesQueryHandlerTests.cs
@@ -1,0 +1,76 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetPages;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetPagesQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetPagesQueryHandler>> _loggerMock;
+    private readonly Mock<IAdminMapper<Domain.Entities.Pages.Page, PageAdminDto>> _mapperMock;
+    private readonly GetPagesQueryHandler _handler;
+
+    public GetPagesQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<IPageRepository>();
+        _loggerMock = new Mock<ILogger<GetPagesQueryHandler>>();
+        _mapperMock = new Mock<IAdminMapper<Domain.Entities.Pages.Page, PageAdminDto>>();
+        _handler = new GetPagesQueryHandler(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenNoPagesFound()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetAllWithTranslationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Domain.Entities.Pages.Page>());
+
+        // Act
+        var result = await _handler.Handle(new GetPagesQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("No pages found.");
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("No pages found.")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenPagesExist()
+    {
+        // Arrange
+        var pages = new List<Domain.Entities.Pages.Page>
+        {
+            PageTestDataFactory.CreatePage(key: "home"),
+            PageTestDataFactory.CreatePage(key: "blog")
+        };
+            
+        var dtos = pages.Select(PageTestDataFactory.MapToAdminDto).ToList();
+
+        _repositoryMock
+            .Setup(r => r.GetAllWithTranslationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pages);
+
+        _mapperMock
+            .Setup(m => m.MapToAdminDtoList(pages))
+            .Returns(dtos);
+
+        // Act
+        var result = await _handler.Handle(new GetPagesQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dtos);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPortfolioPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPortfolioPageQueryHandlerTests.cs
@@ -1,0 +1,158 @@
+using PersonalSite.Application.Common.Localization;
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetPortfolioPage;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Pages;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+
+namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
+
+public class GetPortfolioPageQueryHandlerTests
+{
+    private readonly Mock<IPageRepository> _pageRepositoryMock;
+    private readonly Mock<IProjectRepository> _projectRepositoryMock;
+    private readonly Mock<ILogger<GetPortfolioPageQueryHandler>> _loggerMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
+    private readonly Mock<ITranslatableMapper<Domain.Entities.Projects.Project, ProjectDto>> _projectMapperMock;
+    private readonly LanguageContext _languageContext;
+    private readonly GetPortfolioPageQueryHandler _handler;
+
+    public GetPortfolioPageQueryHandlerTests()
+    {
+        _pageRepositoryMock = new Mock<IPageRepository>();
+        _projectRepositoryMock = new Mock<IProjectRepository>();
+        _loggerMock = new Mock<ILogger<GetPortfolioPageQueryHandler>>();
+        _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
+        _projectMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Projects.Project, ProjectDto>>();
+
+        _languageContext = new LanguageContext { LanguageCode = "en" };
+
+        _handler = new GetPortfolioPageQueryHandler(
+            _languageContext,
+            _pageRepositoryMock.Object,
+            _projectRepositoryMock.Object,
+            _loggerMock.Object,
+            _pageMapperMock.Object,
+            _projectMapperMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLanguageContext_ReturnsFailure()
+    {
+        // Arrange
+        _languageContext.LanguageCode = null!;
+        var query = new GetPortfolioPageQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Invalid language context.");
+    }
+
+    [Fact]
+    public async Task Handle_PageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var query = new GetPortfolioPageQuery();
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("portfolio", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Portfolio page not found.");
+    }
+
+    [Fact]
+    public async Task Handle_NoProjects_ReturnsSuccessWithEmptyList()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = PageTestDataFactory.MapToDto(page);
+        var query = new GetPortfolioPageQuery();
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("portfolio", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _pageMapperMock.Setup(m => m.MapToDto(page, _languageContext.LanguageCode))
+            .Returns(pageDto);
+
+        _projectRepositoryMock.Setup(r => r.GetAllWithFullDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Domain.Entities.Projects.Project>());
+
+        _projectMapperMock.Setup(m => m.MapToDtoList(It.IsAny<List<Domain.Entities.Projects.Project>>(), _languageContext.LanguageCode))
+            .Returns(new List<ProjectDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Projects.Should().BeEmpty();
+        result.Value.PageData.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PageAndProjectsFound_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var pageDto = PageTestDataFactory.MapToDto(page);
+
+        var project = new Domain.Entities.Projects.Project { Id = Guid.NewGuid() };
+        var projectDto = new ProjectDto { Id = project.Id };
+
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync("portfolio", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _pageMapperMock.Setup(m => m.MapToDto(page, _languageContext.LanguageCode))
+            .Returns(pageDto);
+
+        _projectRepositoryMock.Setup(r => r.GetAllWithFullDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([project]);
+
+        _projectMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<Domain.Entities.Projects.Project>>(), _languageContext.LanguageCode))
+            .Returns([projectDto]);
+
+        // Act
+        var result = await _handler.Handle(new GetPortfolioPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageData.Should().Be(pageDto);
+        result.Value.Projects.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailure()
+    {
+        // Arrange
+        _pageRepositoryMock.Setup(r => r.GetByKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB failure"));
+
+        // Act
+        var result = await _handler.Handle(new GetPortfolioPageQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred.");
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving portfolio page data.")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageMapperTests.cs
@@ -1,0 +1,241 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+using PersonalSite.Application.Features.Pages.Page.Mappers;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Pages.Page;
+
+public class PageMapperTests
+{
+    private readonly Mock<IS3UrlBuilder> _urlBuilderMock;
+    private readonly Mock<IMapper<PageTranslation, PageTranslationDto>> _translationMapperMock;
+    private readonly PageMapper _mapper;
+
+    public PageMapperTests()
+    {
+        _urlBuilderMock = new Mock<IS3UrlBuilder>();
+        _translationMapperMock = new Mock<IMapper<PageTranslation, PageTranslationDto>>();
+
+        _mapper = new PageMapper(_urlBuilderMock.Object, _translationMapperMock.Object);
+    }
+
+    [Fact]
+    public void MapToDto_WithMatchingTranslation_ReturnsMappedDto()
+    {
+        // Arrange
+        var languageCode = "en";
+        var ogImageKey = "image.png";
+        var ogImageUrl = "https://s3.amazonaws.com/bucket/image.png";
+
+        var translation = new PageTranslation
+        {
+            Language = new Language { Code = languageCode },
+            Data = new Dictionary<string, string> { { "key", "value" } },
+            Title = "Title",
+            Description = "Description",
+            MetaTitle = "Meta Title",
+            MetaDescription = "Meta Description",
+            OgImage = ogImageKey
+        };
+
+        var page = new Domain.Entities.Pages.Page
+        {
+            Id = Guid.NewGuid(),
+            Key = "page-key",
+            Translations = new List<PageTranslation> { translation }
+        };
+
+        _urlBuilderMock.Setup(u => u.BuildUrl(ogImageKey)).Returns(ogImageUrl);
+
+        // Act
+        var dto = _mapper.MapToDto(page, languageCode);
+
+        // Assert
+        dto.Id.Should().Be(page.Id);
+        dto.Key.Should().Be(page.Key);
+        dto.Data.Should().BeEquivalentTo(translation.Data);
+        dto.Title.Should().Be(translation.Title);
+        dto.Description.Should().Be(translation.Description);
+        dto.MetaTitle.Should().Be(translation.MetaTitle);
+        dto.MetaDescription.Should().Be(translation.MetaDescription);
+        dto.OgImage.Should().Be(ogImageUrl);
+
+        _urlBuilderMock.Verify(u => u.BuildUrl(ogImageKey), Times.Once);
+    }
+
+    [Fact]
+    public void MapToDto_WithNoMatchingTranslation_ReturnsDtoWithDefaults()
+    {
+        // Arrange
+        var languageCode = "fr"; // no matching translation
+        var page = new Domain.Entities.Pages.Page
+        {
+            Id = Guid.NewGuid(),
+            Key = "page-key",
+            Translations = new List<PageTranslation>
+            {
+                new PageTranslation
+                {
+                    Language = new Language { Code = "en" },
+                    Data = new Dictionary<string, string> { { "key", "value" } },
+                    Title = "Title"
+                }
+            }
+        };
+
+        // Act
+        var dto = _mapper.MapToDto(page, languageCode);
+
+        // Assert
+        dto.Id.Should().Be(page.Id);
+        dto.Key.Should().Be(page.Key);
+        dto.Data.Should().BeEmpty();
+        dto.Title.Should().BeEmpty();
+        dto.Description.Should().BeEmpty();
+        dto.MetaTitle.Should().BeEmpty();
+        dto.MetaDescription.Should().BeEmpty();
+        dto.OgImage.Should().BeEmpty();
+
+        _urlBuilderMock.Verify(u => u.BuildUrl(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void MapToDto_WithEmptyOgImage_ReturnsEmptyOgImage()
+    {
+        // Arrange
+        var languageCode = "en";
+        var translation = new PageTranslation
+        {
+            Language = new Language { Code = languageCode },
+            OgImage = "" // empty OgImage
+        };
+        var page = new Domain.Entities.Pages.Page
+        {
+            Id = Guid.NewGuid(),
+            Key = "page-key",
+            Translations = new List<PageTranslation> { translation }
+        };
+
+        // Act
+        var dto = _mapper.MapToDto(page, languageCode);
+
+        // Assert
+        dto.OgImage.Should().BeEmpty();
+        _urlBuilderMock.Verify(u => u.BuildUrl(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void MapToDtoList_ReturnsListOfDtos()
+    {
+        // Arrange
+        var pages = new List<Domain.Entities.Pages.Page>
+        {
+            new Domain.Entities.Pages.Page
+            {
+                Id = Guid.NewGuid(),
+                Key = "page1",
+                Translations = new List<PageTranslation>
+                {
+                    new PageTranslation
+                    {
+                        Language = new Language { Code = "en" },
+                        Title = "Title1"
+                    }
+                }
+            },
+            new Domain.Entities.Pages.Page
+            {
+                Id = Guid.NewGuid(),
+                Key = "page2",
+                Translations = new List<PageTranslation>
+                {
+                    new PageTranslation
+                    {
+                        Language = new Language { Code = "en" },
+                        Title = "Title2"
+                    }
+                }
+            }
+        };
+
+        _urlBuilderMock.Setup(u => u.BuildUrl(It.IsAny<string>())).Returns<string>(s => s);
+
+        // Act
+        var dtos = _mapper.MapToDtoList(pages, "en");
+
+        // Assert
+        dtos.Should().HaveCount(2);
+        dtos.Select(d => d.Title).Should().Contain(new[] { "Title1", "Title2" });
+    }
+
+    [Fact]
+    public void MapToAdminDto_ReturnsMappedAdminDto()
+    {
+        // Arrange
+        var translations = new List<PageTranslation>
+        {
+            new PageTranslation { Id = Guid.NewGuid() },
+            new PageTranslation { Id = Guid.NewGuid() }
+        };
+
+        var page = new Domain.Entities.Pages.Page
+        {
+            Id = Guid.NewGuid(),
+            Key = "page-key",
+            Translations = translations
+        };
+
+        var translationDtos = new List<PageTranslationDto>
+        {
+            new PageTranslationDto(),
+            new PageTranslationDto()
+        };
+
+        _translationMapperMock
+            .Setup(m => m.MapToDtoList(translations))
+            .Returns(translationDtos);
+
+        // Act
+        var adminDto = _mapper.MapToAdminDto(page);
+
+        // Assert
+        adminDto.Id.Should().Be(page.Id);
+        adminDto.Key.Should().Be(page.Key);
+        adminDto.Translations.Should().BeEquivalentTo(translationDtos);
+    }
+
+    [Fact]
+    public void MapToAdminDtoList_ReturnsListOfAdminDtos()
+    {
+        // Arrange
+        var pages = new List<Domain.Entities.Pages.Page>
+        {
+            new Domain.Entities.Pages.Page
+            {
+                Id = Guid.NewGuid(),
+                Key = "page1",
+                Translations = new List<PageTranslation>()
+            },
+            new Domain.Entities.Pages.Page
+            {
+                Id = Guid.NewGuid(),
+                Key = "page2",
+                Translations = new List<PageTranslation>()
+            }
+        };
+
+        // Setup _translationMapperMock to return empty list for any input
+        _translationMapperMock
+            .Setup(m => m.MapToDtoList(It.IsAny<IEnumerable<PageTranslation>>()))
+            .Returns(new List<PageTranslationDto>());
+
+        // Act
+        var adminDtos = _mapper.MapToAdminDtoList(pages);
+
+        // Assert
+        adminDtos.Should().HaveCount(2);
+        adminDtos.Select(d => d.Key).Should().Contain(new[] { "page1", "page2" });
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageTranslationMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageTranslationMapperTests.cs
@@ -1,0 +1,129 @@
+using PersonalSite.Application.Features.Pages.Page.Mappers;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Pages.Page;
+
+public class PageTranslationMapperTests
+{
+    private readonly Mock<IS3UrlBuilder> _urlBuilderMock;
+    private readonly PageTranslationMapper _mapper;
+
+    public PageTranslationMapperTests()
+    {
+        _urlBuilderMock = new Mock<IS3UrlBuilder>();
+        _mapper = new PageTranslationMapper(_urlBuilderMock.Object);
+    }
+
+    [Fact]
+    public void MapToDto_WithValidOgImage_ReturnsMappedDtoWithUrl()
+    {
+        // Arrange
+        var ogImageKey = "image.png";
+        var ogImageUrl = "https://cdn.example.com/image.png";
+        var entity = new PageTranslation
+        {
+            Id = Guid.NewGuid(),
+            Language = new Language { Code = "en" },
+            PageId = Guid.NewGuid(),
+            Data = new Dictionary<string, string> { { "foo", "bar" } },
+            Title = "Title",
+            Description = "Description",
+            MetaTitle = "Meta Title",
+            MetaDescription = "Meta Description",
+            OgImage = ogImageKey
+        };
+
+        _urlBuilderMock.Setup(u => u.BuildUrl(ogImageKey)).Returns(ogImageUrl);
+
+        // Act
+        var dto = _mapper.MapToDto(entity);
+
+        // Assert
+        dto.Id.Should().Be(entity.Id);
+        dto.LanguageCode.Should().Be(entity.Language.Code);
+        dto.PageId.Should().Be(entity.PageId);
+        dto.Data.Should().BeEquivalentTo(entity.Data);
+        dto.Title.Should().Be(entity.Title);
+        dto.Description.Should().Be(entity.Description);
+        dto.MetaTitle.Should().Be(entity.MetaTitle);
+        dto.MetaDescription.Should().Be(entity.MetaDescription);
+        dto.OgImage.Should().Be(ogImageUrl);
+
+        _urlBuilderMock.Verify(u => u.BuildUrl(ogImageKey), Times.Once);
+    }
+
+    [Fact]
+    public void MapToDto_WithNullOrWhitespaceOgImage_ReturnsEmptyOgImage()
+    {
+        // Arrange
+        var entityWithNullOgImage = new PageTranslation
+        {
+            OgImage = null,
+            Language = new Language { Code = "en" }
+        };
+        var entityWithEmptyOgImage = new PageTranslation
+        {
+            OgImage = "",
+            Language = new Language { Code = "en" }
+        };
+        var entityWithWhitespaceOgImage = new PageTranslation
+        {
+            OgImage = "  ",
+            Language = new Language { Code = "en" }
+        };
+
+        // Act
+        var dtoNull = _mapper.MapToDto(entityWithNullOgImage);
+        var dtoEmpty = _mapper.MapToDto(entityWithEmptyOgImage);
+        var dtoWhitespace = _mapper.MapToDto(entityWithWhitespaceOgImage);
+
+        // Assert
+        dtoNull.OgImage.Should().BeEmpty();
+        dtoEmpty.OgImage.Should().BeEmpty();
+        dtoWhitespace.OgImage.Should().BeEmpty();
+
+        _urlBuilderMock.Verify(u => u.BuildUrl(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void MapToDtoList_MapsAllEntities()
+    {
+        // Arrange
+        var entities = new List<PageTranslation>
+        {
+            new PageTranslation
+            {
+                Id = Guid.NewGuid(),
+                Language = new Language { Code = "en" },
+                PageId = Guid.NewGuid(),
+                Title = "Title1",
+                OgImage = "img1.png"
+            },
+            new PageTranslation
+            {
+                Id = Guid.NewGuid(),
+                Language = new Language { Code = "fr" },
+                PageId = Guid.NewGuid(),
+                Title = "Title2",
+                OgImage = null
+            }
+        };
+
+        _urlBuilderMock.Setup(u => u.BuildUrl("img1.png")).Returns("url1");
+
+        // Act
+        var dtos = _mapper.MapToDtoList(entities);
+
+        // Assert
+        dtos.Should().HaveCount(2);
+        dtos[0].OgImage.Should().Be("url1");
+        dtos[0].Title.Should().Be("Title1");
+        dtos[1].OgImage.Should().BeEmpty();
+        dtos[1].Title.Should().Be("Title2");
+
+        _urlBuilderMock.Verify(u => u.BuildUrl("img1.png"), Times.Once);
+        _urlBuilderMock.Verify(u => u.BuildUrl(It.Is<string>(s => s != "img1.png")), Times.Never);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Pages/Page/CreatePageCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Pages/Page/CreatePageCommandValidatorTests.cs
@@ -1,0 +1,64 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Pages.Page.Commands.CreatePage;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Pages.Page;
+
+public class CreatePageCommandValidatorTests
+{
+    private readonly CreatePageCommandValidator _validator;
+
+    public CreatePageCommandValidatorTests()
+    {
+        _validator = new CreatePageCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Key_Is_Empty()
+    {
+        var command = new CreatePageCommand("", new List<PageTranslationDto> { new PageTranslationDto() });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Key)
+            .WithErrorMessage("Key is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Key_Exceeds_MaxLength()
+    {
+        var longKey = new string('a', 51);
+        var command = new CreatePageCommand(longKey, new List<PageTranslationDto> { new PageTranslationDto() });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Key)
+            .WithErrorMessage("Key must be 50 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Translations_Is_Empty()
+    {
+        var command = new CreatePageCommand("valid-key", new List<PageTranslationDto>());
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Translations)
+            .WithErrorMessage("At least one translation is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Valid_Command()
+    {
+        var translations = new List<PageTranslationDto>
+        {
+            new PageTranslationDto { LanguageCode = "en", Title = "Title" }
+        };
+
+        var command = new CreatePageCommand("valid-key", translations);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Pages/Page/DeletePageCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Pages/Page/DeletePageCommandValidatorTests.cs
@@ -1,0 +1,34 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Pages.Page.Commands.DeletePage;
+
+namespace PersonalSite.Application.Tests.Validators.Pages.Page;
+
+public class DeletePageCommandValidatorTests
+{
+    private readonly DeletePageCommandValidator _validator;
+
+    public DeletePageCommandValidatorTests()
+    {
+        _validator = new DeletePageCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new DeletePageCommand(Guid.Empty);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Id);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Not_Empty()
+    {
+        var command = new DeletePageCommand(Guid.NewGuid());
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(c => c.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Pages/Page/GetPageByIdQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Pages/Page/GetPageByIdQueryValidatorTests.cs
@@ -1,0 +1,35 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Pages.Page.Queries.GetPageById;
+
+namespace PersonalSite.Application.Tests.Validators.Pages.Page;
+
+public class GetPageByIdQueryValidatorTests
+{
+    private readonly GetPageByIdQueryValidator _validator;
+
+    public GetPageByIdQueryValidatorTests()
+    {
+        _validator = new GetPageByIdQueryValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var query = new GetPageByIdQuery(Guid.Empty);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(q => q.Id)
+            .WithErrorMessage("Id is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var query = new GetPageByIdQuery(Guid.NewGuid());
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(q => q.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Pages/Page/PageTranslationDtoValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Pages/Page/PageTranslationDtoValidatorTests.cs
@@ -1,0 +1,143 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Pages.Page.Commands.CreatePage;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Pages.Page;
+
+public class PageTranslationDtoValidatorTests
+{
+    private readonly PageTranslationDtoValidator _validator;
+
+    public PageTranslationDtoValidatorTests()
+    {
+        _validator = new PageTranslationDtoValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_LanguageCode_Is_Empty()
+    {
+        var dto = new PageTranslationDto { LanguageCode = "" };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.LanguageCode)
+            .WithErrorMessage("LanguageCode is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_LanguageCode_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { LanguageCode = new string('a', 11) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.LanguageCode)
+            .WithErrorMessage("LanguageCode must be 10 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Title_Is_Empty()
+    {
+        var dto = new PageTranslationDto { Title = "" };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage("Title is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Title_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { Title = new string('a', 256) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage("Title must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_Description()
+    {
+        var dto = new PageTranslationDto { Description = new string('a', 500) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Description_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { Description = new string('a', 501) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage("Description must be 500 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_MetaTitle()
+    {
+        var dto = new PageTranslationDto { MetaTitle = new string('a', 255) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.MetaTitle);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_MetaTitle_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { MetaTitle = new string('a', 256) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.MetaTitle)
+            .WithErrorMessage("MetaTitle must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_MetaDescription()
+    {
+        var dto = new PageTranslationDto { MetaDescription = new string('a', 500) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.MetaDescription);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_MetaDescription_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { MetaDescription = new string('a', 501) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.MetaDescription)
+            .WithErrorMessage("MetaDescription must be 500 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_OgImage()
+    {
+        var dto = new PageTranslationDto { OgImage = new string('a', 255) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.OgImage);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_OgImage_Exceeds_MaxLength()
+    {
+        var dto = new PageTranslationDto { OgImage = new string('a', 256) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.OgImage)
+            .WithErrorMessage("OgImage must be 255 characters or fewer.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Pages/Page/UpdatePageCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Pages/Page/UpdatePageCommandValidatorTests.cs
@@ -1,0 +1,114 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Pages.Page.Commands.UpdatePage;
+using PersonalSite.Application.Features.Pages.Page.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Pages.Page;
+
+public class UpdatePageCommandValidatorTests
+{
+    private readonly UpdatePageCommandValidator _validator;
+
+    public UpdatePageCommandValidatorTests()
+    {
+        _validator = new UpdatePageCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new UpdatePageCommand(
+            Guid.Empty,
+            "valid-key",
+            new List<PageTranslationDto> { new PageTranslationDto { LanguageCode = "en", Title = "Title" } });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Id)
+            .WithErrorMessage("Page ID is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Key_Is_Empty()
+    {
+        var command = new UpdatePageCommand(
+            Guid.NewGuid(),
+            "",
+            new List<PageTranslationDto> { new PageTranslationDto { LanguageCode = "en", Title = "Title" } });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Key)
+            .WithErrorMessage("Key is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Key_Exceeds_MaxLength()
+    {
+        var longKey = new string('a', 51);
+
+        var command = new UpdatePageCommand(
+            Guid.NewGuid(),
+            longKey,
+            new List<PageTranslationDto> { new PageTranslationDto { LanguageCode = "en", Title = "Title" } });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Key)
+            .WithErrorMessage("Key must be 50 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Translations_Is_Empty()
+    {
+        var command = new UpdatePageCommand(
+            Guid.NewGuid(),
+            "valid-key",
+            new List<PageTranslationDto>());
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(c => c.Translations)
+            .WithErrorMessage("At least one translation is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_For_Invalid_Translation()
+    {
+        var translations = new List<PageTranslationDto>
+        {
+            new PageTranslationDto { LanguageCode = "", Title = "" } // invalid translation
+        };
+
+        var command = new UpdatePageCommand(
+            Guid.NewGuid(),
+            "valid-key",
+            translations);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("Translations[0].LanguageCode")
+            .WithErrorMessage("LanguageCode is required.");
+        result.ShouldHaveValidationErrorFor("Translations[0].Title")
+            .WithErrorMessage("Title is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_Command()
+    {
+        var translations = new List<PageTranslationDto>
+        {
+            new PageTranslationDto { LanguageCode = "en", Title = "Valid Title" }
+        };
+
+        var command = new UpdatePageCommand(
+            Guid.NewGuid(),
+            "valid-key",
+            translations);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(c => c.Id);
+        result.ShouldNotHaveValidationErrorFor(c => c.Key);
+        result.ShouldNotHaveValidationErrorFor(c => c.Translations);
+    }
+}


### PR DESCRIPTION
Introduce unit test coverage for all handlers, validators, mappers, and test data factories associated with `Pages`. Includes tests for commands like `CreatePage`, queries like `GetAboutPage`, and their related DTOs and mapping logic.