### PR TITLE
Add comprehensive unit tests for `Projects` feature

### DIFF
--- a/src/PersonalSite.Application/Features/Projects/Project/Commands/CreateProject/CreateProjectCommandValidator.cs
+++ b/src/PersonalSite.Application/Features/Projects/Project/Commands/CreateProject/CreateProjectCommandValidator.cs
@@ -18,13 +18,14 @@ public class CreateProjectCommandValidator : AbstractValidator<CreateProjectComm
         RuleFor(x => x.RepoUrl)
             .MaximumLength(255).WithMessage("RepoUrl must be 255 characters or fewer.")
             .Must(BeValidUrlOrEmpty).WithMessage("RepoUrl must be a valid URL or empty.");
-        
+
         RuleFor(x => x.Translations)
             .NotEmpty().WithMessage("At least one translation is required.");
-      
+
         RuleForEach(x => x.Translations).SetValidator(new ProjectTranslationDtoValidator());
-        
-        RuleForEach(x => x.SkillIds).NotEmpty().WithMessage("At least one skill is required.");
+
+        RuleFor(x => x.SkillIds)
+            .NotEmpty().WithMessage("At least one skill is required.");
     }
     
     private bool BeValidUrlOrEmpty(string url)
@@ -32,6 +33,7 @@ public class CreateProjectCommandValidator : AbstractValidator<CreateProjectComm
         if (string.IsNullOrWhiteSpace(url))
             return true;
 
-        return Uri.TryCreate(url, UriKind.Absolute, out _);
+        return Uri.TryCreate(url, UriKind.Absolute, out var result)
+               && (result.Scheme == Uri.UriSchemeHttp || result.Scheme == Uri.UriSchemeHttps);
     }
 }

--- a/src/PersonalSite.Application/Features/Projects/Project/Commands/UpdateProject/UpdateProjectCommandValidator.cs
+++ b/src/PersonalSite.Application/Features/Projects/Project/Commands/UpdateProject/UpdateProjectCommandValidator.cs
@@ -37,6 +37,7 @@ public class UpdateProjectCommandValidator : AbstractValidator<UpdateProjectComm
         if (string.IsNullOrWhiteSpace(url))
             return true;
 
-        return Uri.TryCreate(url, UriKind.Absolute, out _);
+        return Uri.TryCreate(url, UriKind.Absolute, out var result)
+               && (result.Scheme == Uri.UriSchemeHttp || result.Scheme == Uri.UriSchemeHttps);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ProjectTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ProjectTestDataFactory.cs
@@ -1,0 +1,156 @@
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Features.Skills.SkillCategories.Dtos;
+using PersonalSite.Application.Features.Skills.Skills.Dtos;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Projects;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Entities.Translations;
+
+namespace PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+
+public static class ProjectTestDataFactory
+{
+    public static Project CreateProject(Guid? id = null, string? lanuageCode = null)
+    {
+        var projectId = id ?? Guid.NewGuid();
+        var skillCategoryId = Guid.NewGuid();
+        var skillId = Guid.NewGuid();
+
+        var language = lanuageCode == null 
+            ? CommonTestDataFactory.CreateLanguage() 
+            : CommonTestDataFactory.CreateLanguage(code: lanuageCode);
+        
+        var project = new Project
+        {
+            Id = projectId,
+            Slug = "sample-project",
+            CoverImage = "cover.png",
+            DemoUrl = "https://demo.example.com",
+            RepoUrl = "https://github.com/example/project",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = null,
+            Translations = new List<ProjectTranslation>
+            {
+                new ProjectTranslation
+                {
+                    Id = Guid.NewGuid(),
+                    ProjectId = projectId,
+                    Language = language,
+                    LanguageId = language.Id,
+                    Title = "Sample Project",
+                    ShortDescription = "A test project",
+                    DescriptionSections = new Dictionary<string, string>
+                    {
+                        { "section1", "This is section 1" }
+                    },
+                    MetaTitle = "Meta Title",
+                    MetaDescription = "Meta Description",
+                    OgImage = "ogimage.png"
+                }
+            },
+            ProjectSkills = new List<ProjectSkill>
+            {
+                new ProjectSkill
+                {
+                    Id = Guid.NewGuid(),
+                    ProjectId = projectId,
+                    Skill = new Skill
+                    {
+                        Id = skillId,
+                        Key = "csharp",
+                        Category = new SkillCategory
+                        {
+                            Id = skillCategoryId,
+                            Key = "backend",
+                            DisplayOrder = 1,
+                            Translations = new List<SkillCategoryTranslation>
+                            {
+                                new SkillCategoryTranslation
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Language = language,
+                                    LanguageId = language.Id,
+                                    SkillCategoryId = skillCategoryId,
+                                    Name = "Backend",
+                                    Description = "Backend skills"
+                                }
+                            }
+                        },
+                        Translations = new List<SkillTranslation>
+                        {
+                            new SkillTranslation
+                            {
+                                Id = Guid.NewGuid(),
+                                Language = language,
+                                LanguageId = language.Id,
+                                SkillId = skillId,
+                                Name = "C#",
+                                Description = "C# programming language"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        return project;
+    }
+
+    public static ProjectAdminDto MapToAdminDto(Project project)
+    {
+        return new ProjectAdminDto
+        {
+            Id = project.Id,
+            Slug = project.Slug,
+            CoverImage = project.CoverImage,
+            DemoUrl = project.DemoUrl,
+            RepoUrl = project.RepoUrl,
+            CreatedAt = project.CreatedAt,
+            UpdatedAt = project.UpdatedAt,
+            Translations = project.Translations.Select(t => new ProjectTranslationDto
+            {
+                Id = t.Id,
+                LanguageCode = t.Language.Code,
+                ProjectId = t.ProjectId,
+                Title = t.Title,
+                ShortDescription = t.ShortDescription,
+                DescriptionSections = t.DescriptionSections,
+                MetaTitle = t.MetaTitle,
+                MetaDescription = t.MetaDescription,
+                OgImage = t.OgImage
+            }).ToList(),
+            Skills = project.ProjectSkills.Select(ps => new ProjectSkillAdminDto
+            {
+                Id = ps.Id,
+                ProjectId = ps.ProjectId,
+                Skill = new SkillAdminDto
+                {
+                    Id = ps.Skill.Id,
+                    Key = ps.Skill.Key,
+                    Category = new SkillCategoryAdminDto
+                    {
+                        Id = ps.Skill.Category.Id,
+                        Key = ps.Skill.Category.Key,
+                        DisplayOrder = ps.Skill.Category.DisplayOrder,
+                        Translations = ps.Skill.Category.Translations.Select(ct => new SkillCategoryTranslationDto
+                        {
+                            Id = ct.Id,
+                            LanguageCode = ct.Language.Code,
+                            SkillCategoryId = ct.SkillCategoryId,
+                            Name = ct.Name,
+                            Description = ct.Description
+                        }).ToList()
+                    },
+                    Translations = ps.Skill.Translations.Select(st => new SkillTranslationDto
+                    {
+                        Id = st.Id,
+                        LanguageCode = st.Language.Code,
+                        SkillId = st.SkillId,
+                        Name = st.Name,
+                        Description = st.Description
+                    }).ToList()
+                }
+            }).ToList()
+        };
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/CreateProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/CreateProjectCommandHandlerTests.cs
@@ -1,0 +1,145 @@
+using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+using PersonalSite.Domain.Interfaces.Repositories.Skills;
+using PersonalSite.Domain.Interfaces.Repositories.Translations;
+
+namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
+
+public class CreateProjectCommandHandlerTests
+{
+    private readonly Mock<IProjectRepository> _projectRepositoryMock = new();
+    private readonly Mock<ILanguageRepository> _languageRepositoryMock = new();
+    private readonly Mock<IProjectTranslationRepository> _translationRepositoryMock = new();
+    private readonly Mock<IProjectSkillRepository> _projectSkillRepositoryMock = new();
+    private readonly Mock<ISkillRepository> _skillRepositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<CreateProjectCommandHandler>> _loggerMock = new();
+
+    private readonly CreateProjectCommandHandler _handler;
+
+    public CreateProjectCommandHandlerTests()
+    {
+        _handler = new CreateProjectCommandHandler(
+            _projectRepositoryMock.Object,
+            _languageRepositoryMock.Object,
+            _translationRepositoryMock.Object,
+            _projectSkillRepositoryMock.Object,
+            _skillRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenSlugNotAvailable()
+    {
+        var command = new CreateProjectCommand { Slug = "existing-slug" };
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Slug is already in use.");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenLanguageNotFound()
+    {
+        var command = new CreateProjectCommand
+        {
+            Slug = "new-slug",
+            Translations =
+            [
+                new()
+                {
+                    LanguageCode = "en", Title = "Title", ShortDescription = "", DescriptionSections = new(),
+                    MetaTitle = "", MetaDescription = "", OgImage = ""
+                }
+            ]
+        };
+
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(l => l.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Language?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Language 'en' not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenSkillNotFound()
+    {
+        var command = new CreateProjectCommand
+        {
+            Slug = "new-slug",
+            Translations =
+            [
+                new()
+                {
+                    LanguageCode = "en", Title = "Title", ShortDescription = "", DescriptionSections = new(),
+                    MetaTitle = "", MetaDescription = "", OgImage = ""
+                }
+            ],
+            SkillIds = [Guid.NewGuid()]
+        };
+
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(l => l.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Language { Id = Guid.NewGuid(), Code = "en" });
+
+        _skillRepositoryMock.Setup(s => s.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Skill?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("Skill with ID");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenValid()
+    {
+        var skillId = Guid.NewGuid();
+        var command = new CreateProjectCommand
+        {
+            Slug = "valid-slug",
+            Translations =
+            [
+                new()
+                {
+                    LanguageCode = "en", Title = "Valid Title", ShortDescription = "", DescriptionSections = new(),
+                    MetaTitle = "", MetaDescription = "", OgImage = ""
+                }
+            ],
+            SkillIds = [skillId]
+        };
+
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(l => l.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Language { Id = Guid.NewGuid(), Code = "en" });
+
+        _skillRepositoryMock.Setup(s => s.GetByIdAsync(skillId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Skill { Id = skillId });
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBe(Guid.Empty);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/DeleteProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/DeleteProjectCommandHandlerTests.cs
@@ -1,0 +1,87 @@
+using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
+using PersonalSite.Application.Features.Projects.Project.Commands.DeleteProject;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+
+namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
+
+public class DeleteProjectCommandHandlerTests
+{
+    private readonly Mock<IProjectRepository> _projectRepositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<CreateProjectCommandHandler>> _loggerMock = new();
+
+    private readonly DeleteProjectCommandHandler _handler;
+
+    public DeleteProjectCommandHandlerTests()
+    {
+        _handler = new DeleteProjectCommandHandler(
+            _projectRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenProjectNotFound()
+    {
+        // Arrange
+        var projectId = Guid.NewGuid();
+        _projectRepositoryMock.Setup(r => r.GetByIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Projects.Project?)null);
+
+        var command = new DeleteProjectCommand(projectId);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be($"Project with ID {projectId} not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenProjectDeleted()
+    {
+        // Arrange
+        var projectId = Guid.NewGuid();
+        var project = new Domain.Entities.Projects.Project { Id = projectId };
+
+        _projectRepositoryMock.Setup(r => r.GetByIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(project);
+
+        _unitOfWorkMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var command = new DeleteProjectCommand(projectId);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        project.IsDeleted.Should().BeTrue();
+        project.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+
+        _projectRepositoryMock.Verify(r => r.UpdateAsync(project, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var projectId = Guid.NewGuid();
+
+        _projectRepositoryMock.Setup(r => r.GetByIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB failure"));
+
+        var command = new DeleteProjectCommand(projectId);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Error deleting project.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectByIdQueryHandlerTests.cs
@@ -1,0 +1,86 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Features.Projects.Project.Queries.GetProjectById;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+
+namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
+
+public class GetProjectByIdQueryHandlerTests
+{
+    private readonly Mock<IProjectRepository> _repositoryMock;
+    private readonly Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>> _mapperMock;
+    private readonly Mock<ILogger<GetProjectByIdQueryHandler>> _loggerMock;
+    private readonly GetProjectByIdQueryHandler _handler;
+
+    public GetProjectByIdQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<IProjectRepository>();
+        _mapperMock = new Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>>();
+        _loggerMock = new Mock<ILogger<GetProjectByIdQueryHandler>>();
+
+        _handler = new GetProjectByIdQueryHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenProjectExists()
+    {
+        // Arrange
+        var project = ProjectTestDataFactory.CreateProject();
+        var dto = ProjectTestDataFactory.MapToAdminDto(project);
+
+        _repositoryMock.Setup(r => r.GetWithFullDataAsync(project.Id, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(project);
+        _mapperMock.Setup(m => m.MapToAdminDto(project)).Returns(dto);
+
+        var query = new GetProjectByIdQuery(project.Id);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(dto);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenProjectNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _repositoryMock.Setup(r => r.GetWithFullDataAsync(id, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync((Domain.Entities.Projects.Project?)null);
+
+        var query = new GetProjectByIdQuery(id);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Project not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _repositoryMock.Setup(r => r.GetWithFullDataAsync(id, It.IsAny<CancellationToken>()))
+                       .ThrowsAsync(new Exception("Database error"));
+
+        var query = new GetProjectByIdQuery(id);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Error getting project by id.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectsQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectsQueryHandlerTests.cs
@@ -1,0 +1,96 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Features.Projects.Project.Queries.GetProjects;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Common.Results;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+
+namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
+
+public class GetProjectsQueryHandlerTests
+{
+    private readonly Mock<IProjectRepository> _projectRepositoryMock;
+    private readonly Mock<ILogger<GetProjectsQueryHandler>> _loggerMock;
+    private readonly Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>> _mapperMock;
+    private readonly GetProjectsQueryHandler _handler;
+
+    public GetProjectsQueryHandlerTests()
+    {
+        _projectRepositoryMock = new Mock<IProjectRepository>();
+        _loggerMock = new Mock<ILogger<GetProjectsQueryHandler>>();
+        _mapperMock = new Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>>();
+
+        _handler = new GetProjectsQueryHandler(
+            _projectRepositoryMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenProjectsFound()
+    {
+        // Arrange
+        var query = new GetProjectsQuery();
+        var project = ProjectTestDataFactory.CreateProject();
+        var dto = ProjectTestDataFactory.MapToAdminDto(project);
+
+        var paginatedResult = PaginatedResult<Domain.Entities.Projects.Project>.Success(
+            [project], 1, 10, 1);
+
+        _projectRepositoryMock
+            .Setup(r => r.GetFilteredAsync(1, 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginatedResult);
+
+        _mapperMock
+            .Setup(m => m.MapToAdminDtoList(It.Is<IEnumerable<Domain.Entities.Projects.Project>>(l => l.Contains(project))))
+            .Returns([dto]);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+        result.Value.First().Id.Should().Be(project.Id);
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(10);
+        result.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenRepositoryFails()
+    {
+        // Arrange
+        var query = new GetProjectsQuery();
+        var failureResult = PaginatedResult<Domain.Entities.Projects.Project>.Failure("Projects not found.");
+
+        _projectRepositoryMock
+            .Setup(r => r.GetFilteredAsync(query.Page, query.PageSize, query.SlugFilter, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(failureResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Projects not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenExceptionThrown()
+    {
+        // Arrange
+        var query = new GetProjectsQuery();
+
+        _projectRepositoryMock
+            .Setup(r => r.GetFilteredAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database down"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Error getting projects.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/UpdateProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/UpdateProjectCommandHandlerTests.cs
@@ -1,0 +1,130 @@
+using PersonalSite.Application.Features.Projects.Project.Commands.UpdateProject;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Domain.Interfaces.Repositories.Common;
+using PersonalSite.Domain.Interfaces.Repositories.Projects;
+using PersonalSite.Domain.Interfaces.Repositories.Skills;
+using PersonalSite.Domain.Interfaces.Repositories.Translations;
+
+namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
+
+public class UpdateProjectCommandHandlerTests
+{
+    private readonly Mock<IProjectRepository> _projectRepositoryMock = new();
+    private readonly Mock<ILanguageRepository> _languageRepositoryMock = new();
+    private readonly Mock<IProjectTranslationRepository> _translationRepositoryMock = new();
+    private readonly Mock<IProjectSkillRepository> _projectSkillRepositoryMock = new();
+    private readonly Mock<ISkillRepository> _skillRepositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<UpdateProjectCommandHandler>> _loggerMock = new();
+
+    private readonly UpdateProjectCommandHandler _handler;
+
+    public UpdateProjectCommandHandlerTests()
+    {
+        _handler = new UpdateProjectCommandHandler(
+            _projectRepositoryMock.Object,
+            _languageRepositoryMock.Object,
+            _translationRepositoryMock.Object,
+            _projectSkillRepositoryMock.Object,
+            _skillRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenProjectNotFound()
+    {
+        // Arrange
+        var command = new UpdateProjectCommand { Id = Guid.NewGuid() };
+        _projectRepositoryMock.Setup(r => r.GetWithFullDataAsync(command.Id, CancellationToken.None))
+            .ReturnsAsync((Domain.Entities.Projects.Project?)null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenSlugAlreadyUsed()
+    {
+        // Arrange
+        var command = new UpdateProjectCommand { Id = Guid.NewGuid(), Slug = "existing-slug" };
+        var project = new Domain.Entities.Projects.Project { Id = command.Id, Slug = "old-slug" };
+
+        _projectRepositoryMock.Setup(r => r.GetWithFullDataAsync(command.Id, CancellationToken.None))
+            .ReturnsAsync(project);
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, CancellationToken.None))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("slug already exists");
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccess_WhenUpdateSucceeds()
+    {
+        // Arrange
+        var projectId = Guid.NewGuid();
+        var skillId = Guid.NewGuid();
+        var languageId = Guid.NewGuid();
+
+        var command = new UpdateProjectCommand
+        {
+            Id = projectId,
+            Slug = "updated-slug",
+            CoverImage = "new-image.png",
+            DemoUrl = "demo.com",
+            RepoUrl = "repo.com",
+            SkillIds = [skillId],
+            Translations = [
+                new ProjectTranslationDto
+                {
+                    LanguageCode = "en",
+                    Title = "Title",
+                    ShortDescription = "Short desc",
+                    DescriptionSections = new(),
+                    MetaTitle = "Meta",
+                    MetaDescription = "Meta desc",
+                    OgImage = "og.png"
+                }
+            ]
+        };
+
+        var language = new Language { Id = languageId, Code = "en" };
+        var project = new Domain.Entities.Projects.Project { Id = projectId, Slug = "old-slug", ProjectSkills = [], Translations = [] };
+
+        _projectRepositoryMock.Setup(r => r.GetWithFullDataAsync(projectId, CancellationToken.None))
+            .ReturnsAsync(project);
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync("updated-slug", CancellationToken.None))
+            .ReturnsAsync(true);
+
+        _languageRepositoryMock.Setup(r => r.GetByCodeAsync("en", CancellationToken.None))
+            .ReturnsAsync(language);
+
+        _translationRepositoryMock.Setup(r => r.GetByProjectIdAsync(projectId, CancellationToken.None))
+            .ReturnsAsync(new List<ProjectTranslation>());
+
+        _projectSkillRepositoryMock.Setup(r => r.GetByProjectIdAsync(projectId, CancellationToken.None))
+            .ReturnsAsync(new List<ProjectSkill>());
+
+        _skillRepositoryMock.Setup(r => r.GetByIdAsync(skillId, CancellationToken.None))
+            .ReturnsAsync(new Skill { Id = skillId });
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(CancellationToken.None), Times.Once);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectMapperTests.cs
@@ -1,0 +1,75 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Features.Projects.Project.Mappers;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
+using PersonalSite.Domain.Entities.Skills;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Projects.Project;
+
+public class ProjectMapperTests
+{
+    private readonly Mock<IS3UrlBuilder> _s3UrlBuilderMock;
+    private readonly Mock<ITranslatableMapper<ProjectSkill, ProjectSkillDto>> _skillMapperMock;
+    private readonly Mock<IAdminMapper<ProjectSkill, ProjectSkillAdminDto>> _skillAdminMapperMock;
+    private readonly Mock<IMapper<ProjectTranslation, ProjectTranslationDto>> _translationMapperMock;
+    private readonly ProjectMapper _mapper;
+
+    public ProjectMapperTests()
+    {
+        _s3UrlBuilderMock = new Mock<IS3UrlBuilder>();
+        _skillMapperMock = new Mock<ITranslatableMapper<ProjectSkill, ProjectSkillDto>>();
+        _skillAdminMapperMock = new Mock<IAdminMapper<ProjectSkill, ProjectSkillAdminDto>>();
+        _translationMapperMock = new Mock<IMapper<ProjectTranslation, ProjectTranslationDto>>();
+
+        _mapper = new ProjectMapper(
+            _s3UrlBuilderMock.Object,
+            _skillMapperMock.Object,
+            _skillAdminMapperMock.Object,
+            _translationMapperMock.Object);
+    }
+
+    [Fact]
+    public void MapToAdminDto_MapsCorrectly()
+    {
+        // Arrange
+        var entity = ProjectTestDataFactory.CreateProject();
+        var translationDtos = entity.Translations.Select(t => new ProjectTranslationDto { Id = t.Id }).ToList();
+        var skillDtos = entity.ProjectSkills.Select(s => new ProjectSkillAdminDto { Id = s.Id }).ToList();
+
+        _translationMapperMock.Setup(m => m.MapToDtoList(entity.Translations)).Returns(translationDtos);
+        _skillAdminMapperMock.Setup(m => m.MapToAdminDtoList(entity.ProjectSkills)).Returns(skillDtos);
+
+        // Act
+        var result = _mapper.MapToAdminDto(entity);
+
+        // Assert
+        result.Id.Should().Be(entity.Id);
+        result.Slug.Should().Be(entity.Slug);
+        result.Translations.Should().BeEquivalentTo(translationDtos);
+        result.Skills.Should().BeEquivalentTo(skillDtos);
+    }
+
+    [Fact]
+    public void MapToDto_MapsCorrectly()
+    {
+        // Arrange
+        var languageCode = "en";
+        var entity = ProjectTestDataFactory.CreateProject();
+        var translation = entity.Translations.First(t => t.Language.Code == languageCode);
+        var skills = new List<ProjectSkillDto> { new ProjectSkillDto { Id = Guid.NewGuid() } };
+
+        _s3UrlBuilderMock.Setup(b => b.BuildUrl(It.IsAny<string>())).Returns<string>(x => $"https://cdn.test/{x}");
+        _skillMapperMock.Setup(m => m.MapToDtoList(entity.ProjectSkills, languageCode)).Returns(skills);
+
+        // Act
+        var result = _mapper.MapToDto(entity, languageCode);
+
+        // Assert
+        result.Id.Should().Be(entity.Id);
+        result.Slug.Should().Be(entity.Slug);
+        result.Title.Should().Be(translation.Title);
+        result.Skills.Should().BeEquivalentTo(skills);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectSkillMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectSkillMapperTests.cs
@@ -1,0 +1,115 @@
+using PersonalSite.Application.Common.Mapping;
+using PersonalSite.Application.Features.Projects.Project.Mappers;
+using PersonalSite.Application.Features.Skills.Skills.Dtos;
+using PersonalSite.Domain.Entities.Skills;
+
+namespace PersonalSite.Application.Tests.Mappers.Projects.Project;
+
+public class ProjectSkillMapperTests
+{
+    private readonly Mock<ITranslatableMapper<Skill, SkillDto>> _skillMapperMock = new();
+    private readonly Mock<IAdminMapper<Skill, SkillAdminDto>> _skillAdminMapperMock = new();
+    private readonly ProjectSkillMapper _mapper;
+
+    public ProjectSkillMapperTests()
+    {
+        _mapper = new ProjectSkillMapper(_skillMapperMock.Object, _skillAdminMapperMock.Object);
+    }
+
+    [Fact]
+    public void MapToDto_Should_Map_Properties_Correctly()
+    {
+        // Arrange
+        var skill = new Skill { Id = Guid.NewGuid(), Key = "csharp" };
+        var skillDto = new SkillDto { Id = skill.Id, Key = "csharp" };
+
+        var projectSkill = new ProjectSkill
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = Guid.NewGuid(),
+            Skill = skill
+        };
+
+        _skillMapperMock.Setup(m => m.MapToDto(skill, "en")).Returns(skillDto);
+
+        // Act
+        var result = _mapper.MapToDto(projectSkill, "en");
+
+        // Assert
+        result.Id.Should().Be(projectSkill.Id);
+        result.ProjectId.Should().Be(projectSkill.ProjectId);
+        result.Skill.Should().BeEquivalentTo(skillDto);
+    }
+
+    [Fact]
+    public void MapToDtoList_Should_Map_All_Items()
+    {
+        // Arrange
+        var skill = new Skill { Id = Guid.NewGuid(), Key = "csharp" };
+        var skillDto = new SkillDto { Id = skill.Id, Key = "csharp" };
+
+        var projectSkillList = new List<ProjectSkill>
+        {
+            new() { Id = Guid.NewGuid(), ProjectId = Guid.NewGuid(), Skill = skill },
+            new() { Id = Guid.NewGuid(), ProjectId = Guid.NewGuid(), Skill = skill }
+        };
+
+        _skillMapperMock.Setup(m => m.MapToDto(It.IsAny<Skill>(), "en"))
+            .Returns(skillDto);
+
+        // Act
+        var result = _mapper.MapToDtoList(projectSkillList, "en");
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.All(ps => ps.Skill.Key == "csharp").Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapToAdminDto_Should_Map_Properties_Correctly()
+    {
+        // Arrange
+        var skill = new Skill { Id = Guid.NewGuid(), Key = "csharp" };
+        var skillAdminDto = new SkillAdminDto { Id = skill.Id, Key = "csharp" };
+
+        var projectSkill = new ProjectSkill
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = Guid.NewGuid(),
+            Skill = skill
+        };
+
+        _skillAdminMapperMock.Setup(m => m.MapToAdminDto(skill)).Returns(skillAdminDto);
+
+        // Act
+        var result = _mapper.MapToAdminDto(projectSkill);
+
+        // Assert
+        result.Id.Should().Be(projectSkill.Id);
+        result.ProjectId.Should().Be(projectSkill.ProjectId);
+        result.Skill.Should().BeEquivalentTo(skillAdminDto);
+    }
+
+    [Fact]
+    public void MapToAdminDtoList_Should_Map_All_Items()
+    {
+        // Arrange
+        var skill = new Skill { Id = Guid.NewGuid(), Key = "csharp" };
+        var skillAdminDto = new SkillAdminDto { Id = skill.Id, Key = "csharp" };
+
+        var projectSkills = new List<ProjectSkill>
+        {
+            new() { Id = Guid.NewGuid(), ProjectId = Guid.NewGuid(), Skill = skill },
+            new() { Id = Guid.NewGuid(), ProjectId = Guid.NewGuid(), Skill = skill }
+        };
+
+        _skillAdminMapperMock.Setup(m => m.MapToAdminDto(It.IsAny<Skill>())).Returns(skillAdminDto);
+
+        // Act
+        var result = _mapper.MapToAdminDtoList(projectSkills);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.All(p => p.Skill.Key == "csharp").Should().BeTrue();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectTranslationMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Projects/Project/ProjectTranslationMapperTests.cs
@@ -1,0 +1,111 @@
+using PersonalSite.Application.Features.Projects.Project.Mappers;
+using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Domain.Entities.Translations;
+using PersonalSite.Infrastructure.Storage;
+
+namespace PersonalSite.Application.Tests.Mappers.Projects.Project;
+
+public class ProjectTranslationMapperTests
+{
+    private readonly Mock<IS3UrlBuilder> _s3UrlBuilderMock = new();
+    private readonly ProjectTranslationMapper _mapper;
+
+    public ProjectTranslationMapperTests()
+    {
+        _mapper = new ProjectTranslationMapper(_s3UrlBuilderMock.Object);
+    }
+
+    [Fact]
+    public void MapToDto_Should_Map_All_Fields_Correctly_With_OgImage()
+    {
+        // Arrange
+        var ogImage = "image.jpg";
+        var fullUrl = "https://s3.com/image.jpg";
+
+        var entity = new ProjectTranslation
+        {
+            Id = Guid.NewGuid(),
+            Language = new Language { Code = "en" },
+            ProjectId = Guid.NewGuid(),
+            Title = "Test Title",
+            ShortDescription = "Short Desc",
+            DescriptionSections = new Dictionary<string, string> { { "section", "text" } },
+            MetaTitle = "Meta Title",
+            MetaDescription = "Meta Description",
+            OgImage = ogImage
+        };
+
+        _s3UrlBuilderMock.Setup(s => s.BuildUrl(ogImage)).Returns(fullUrl);
+
+        // Act
+        var dto = _mapper.MapToDto(entity);
+
+        // Assert
+        dto.Id.Should().Be(entity.Id);
+        dto.LanguageCode.Should().Be("en");
+        dto.ProjectId.Should().Be(entity.ProjectId);
+        dto.Title.Should().Be(entity.Title);
+        dto.ShortDescription.Should().Be(entity.ShortDescription);
+        dto.DescriptionSections.Should().BeEquivalentTo(entity.DescriptionSections);
+        dto.MetaTitle.Should().Be(entity.MetaTitle);
+        dto.MetaDescription.Should().Be(entity.MetaDescription);
+        dto.OgImage.Should().Be(fullUrl);
+    }
+
+    [Fact]
+    public void MapToDto_Should_Return_Empty_OgImage_If_Null_Or_Whitespace()
+    {
+        // Arrange
+        var entity = new ProjectTranslation
+        {
+            Id = Guid.NewGuid(),
+            Language = new Language { Code = "en" },
+            ProjectId = Guid.NewGuid(),
+            OgImage = ""
+        };
+
+        // Act
+        var dto = _mapper.MapToDto(entity);
+
+        // Assert
+        dto.OgImage.Should().BeEmpty();
+        _s3UrlBuilderMock.Verify(s => s.BuildUrl(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void MapToDtoList_Should_Map_All_Items()
+    {
+        // Arrange
+        var translation1 = new ProjectTranslation
+        {
+            Id = Guid.NewGuid(),
+            Language = new Language { Code = "en" },
+            ProjectId = Guid.NewGuid(),
+            Title = "Title1",
+            OgImage = "image1.jpg"
+        };
+
+        var translation2 = new ProjectTranslation
+        {
+            Id = Guid.NewGuid(),
+            Language = new Language { Code = "fr" },
+            ProjectId = Guid.NewGuid(),
+            Title = "Title2",
+            OgImage = ""
+        };
+
+        _s3UrlBuilderMock.Setup(s => s.BuildUrl("image1.jpg")).Returns("https://s3.com/image1.jpg");
+
+        var entities = new List<ProjectTranslation> { translation1, translation2 };
+
+        // Act
+        var result = _mapper.MapToDtoList(entities);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result[0].Title.Should().Be("Title1");
+        result[0].OgImage.Should().Be("https://s3.com/image1.jpg");
+        result[1].Title.Should().Be("Title2");
+        result[1].OgImage.Should().BeEmpty();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/CreateProjectCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/CreateProjectCommandValidatorTests.cs
@@ -1,0 +1,125 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class CreateProjectCommandValidatorTests
+{
+    private readonly CreateProjectCommandValidator _validator;
+
+    public CreateProjectCommandValidatorTests()
+    {
+        _validator = new CreateProjectCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Slug_Is_Empty()
+    {
+        var model = new CreateProjectCommand { Slug = "" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Slug);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Slug_Too_Long()
+    {
+        var model = new CreateProjectCommand { Slug = new string('a', 101) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Slug);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_CoverImage_Too_Long()
+    {
+        var model = new CreateProjectCommand { CoverImage = new string('a', 256) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.CoverImage);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("ftp://example.com")]
+    public void Should_Have_Error_When_DemoUrl_Is_Invalid(string invalidUrl)
+    {
+        var model = new CreateProjectCommand { DemoUrl = invalidUrl };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.DemoUrl);
+    }
+
+    [Theory]
+    [InlineData("http://valid.com")]
+    [InlineData("https://secure.com")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Should_Not_Have_Error_When_DemoUrl_Is_Valid_Or_Empty(string url)
+    {
+        var model = new CreateProjectCommand { DemoUrl = url };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.DemoUrl);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("ftp://example.com")]
+    public void Should_Have_Error_When_RepoUrl_Is_Invalid(string invalidUrl)
+    {
+        var model = new CreateProjectCommand { RepoUrl = invalidUrl };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.RepoUrl);
+    }
+
+    [Theory]
+    [InlineData("http://valid.com")]
+    [InlineData("https://secure.com")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Should_Not_Have_Error_When_RepoUrl_Is_Valid_Or_Empty(string url)
+    {
+        var model = new CreateProjectCommand { RepoUrl = url };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.RepoUrl);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Translations_Is_Empty()
+    {
+        var model = new CreateProjectCommand { Translations = new List<ProjectTranslationDto>() };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Translations);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_SkillIds_Is_Empty()
+    {
+        var model = new CreateProjectCommand { SkillIds = new List<Guid>() };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.SkillIds);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_Model()
+    {
+        var model = new CreateProjectCommand
+        {
+            Slug = "valid-slug",
+            CoverImage = "image.jpg",
+            DemoUrl = "https://demo.com",
+            RepoUrl = "https://repo.com",
+            Translations = new List<ProjectTranslationDto>
+            {
+                new ProjectTranslationDto
+                {
+                    LanguageCode = "en",
+                    Title = "Title",
+                    MetaTitle = "MetaTitle",
+                    MetaDescription = "MetaDescription",
+                    OgImage = "ogimage.jpg"
+                }
+            },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/DeleteProjectCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/DeleteProjectCommandValidatorTests.cs
@@ -1,0 +1,31 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Commands.DeleteProject;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class DeleteProjectCommandValidatorTests
+{
+    private readonly DeleteProjectCommandValidator _validator;
+
+    public DeleteProjectCommandValidatorTests()
+    {
+        _validator = new DeleteProjectCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var model = new DeleteProjectCommand(Guid.Empty);
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Id is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var model = new DeleteProjectCommand(Guid.NewGuid());
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectByIdQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectByIdQueryValidatorTests.cs
@@ -1,0 +1,33 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Queries.GetProjectById;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class GetProjectByIdQueryValidatorTests
+{
+    private readonly GetProjectByIdQueryValidator _validator;
+
+    public GetProjectByIdQueryValidatorTests()
+    {
+        _validator = new GetProjectByIdQueryValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var query = new GetProjectByIdQuery(Guid.Empty);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Id is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Id_Is_Valid()
+    {
+        var query = new GetProjectByIdQuery(Guid.NewGuid());
+
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectsQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectsQueryValidatorTests.cs
@@ -1,0 +1,86 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Queries.GetProjects;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class GetProjectsQueryValidatorTests
+{
+    private readonly GetProjectsQueryValidator _validator;
+
+    public GetProjectsQueryValidatorTests()
+    {
+        _validator = new GetProjectsQueryValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Should_Have_Error_When_Page_Is_Less_Than_1(int page)
+    {
+        var query = new GetProjectsQuery(Page: page);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(x => x.Page)
+            .WithErrorMessage("Page must be greater than 0.");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_Page_Is_Valid(int page)
+    {
+        var query = new GetProjectsQuery(Page: page);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(x => x.Page);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(1000)]
+    public void Should_Have_Error_When_PageSize_Is_Out_Of_Range(int pageSize)
+    {
+        var query = new GetProjectsQuery(PageSize: pageSize);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(x => x.PageSize)
+            .WithErrorMessage("PageSize must be between 1 and 100.");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void Should_Not_Have_Error_When_PageSize_Is_Valid(int pageSize)
+    {
+        var query = new GetProjectsQuery(PageSize: pageSize);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(x => x.PageSize);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_SlugFilter_Too_Long()
+    {
+        var longSlug = new string('a', 101);
+        var query = new GetProjectsQuery(SlugFilter: longSlug);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldHaveValidationErrorFor(x => x.SlugFilter)
+            .WithErrorMessage("SlugFilter must be 100 characters or fewer.");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("valid-slug-filter")]
+    public void Should_Not_Have_Error_When_SlugFilter_Is_Valid(string slugFilter)
+    {
+        var query = new GetProjectsQuery(SlugFilter: slugFilter);
+
+        var result = _validator.TestValidate(query);
+        result.ShouldNotHaveValidationErrorFor(x => x.SlugFilter);
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/ProjectTranslationDtoValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/ProjectTranslationDtoValidatorTests.cs
@@ -1,0 +1,94 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class ProjectTranslationDtoValidatorTests
+{
+    private readonly ProjectTranslationDtoValidator _validator;
+
+    public ProjectTranslationDtoValidatorTests()
+    {
+        _validator = new ProjectTranslationDtoValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_LanguageCode_Is_Null_Or_Empty()
+    {
+        var model = new ProjectTranslationDto { LanguageCode = "" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.LanguageCode)
+            .WithErrorMessage("Language code is required");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_LanguageCode_Too_Long()
+    {
+        var model = new ProjectTranslationDto { LanguageCode = new string('a', 11) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.LanguageCode)
+            .WithErrorMessage("Language code must be 10 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Title_Is_Null_Or_Empty()
+    {
+        var model = new ProjectTranslationDto { Title = "" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage("Title is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Title_Too_Long()
+    {
+        var model = new ProjectTranslationDto { Title = new string('a', 201) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage("Title must be 200 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_MetaTitle_Too_Long()
+    {
+        var model = new ProjectTranslationDto { MetaTitle = new string('a', 256) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.MetaTitle)
+            .WithErrorMessage("MetaTitle must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_MetaDescription_Too_Long()
+    {
+        var model = new ProjectTranslationDto { MetaDescription = new string('a', 501) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.MetaDescription)
+            .WithErrorMessage("MetaDescription must be 500 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_OgImage_Too_Long()
+    {
+        var model = new ProjectTranslationDto { OgImage = new string('a', 256) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.OgImage)
+            .WithErrorMessage("OgImage must be 255 characters or fewer.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Errors_When_Valid()
+    {
+        var model = new ProjectTranslationDto
+        {
+            LanguageCode = "en",
+            Title = "Valid Title",
+            MetaTitle = "Valid MetaTitle",
+            MetaDescription = "Valid MetaDescription",
+            OgImage = "validimage.jpg"
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/UpdateProjectCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/UpdateProjectCommandValidatorTests.cs
@@ -1,0 +1,190 @@
+using FluentValidation.TestHelper;
+using PersonalSite.Application.Features.Projects.Project.Commands.UpdateProject;
+using PersonalSite.Application.Features.Projects.Project.Dtos;
+
+namespace PersonalSite.Application.Tests.Validators.Projects.Project;
+
+public class UpdateProjectCommandValidatorTests
+{
+    private readonly UpdateProjectCommandValidator _validator;
+
+    public UpdateProjectCommandValidatorTests()
+    {
+        _validator = new UpdateProjectCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.Empty,
+            Slug = "valid-slug",
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Project ID is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Slug_Is_Empty()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "",
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Slug)
+            .WithErrorMessage("Slug is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Slug_Is_Too_Long()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = new string('a', 101),
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Slug)
+            .WithErrorMessage("Slug must be 100 characters or fewer.");
+    }
+
+    [Theory]
+    [InlineData("http://validurl.com")]
+    [InlineData("https://validurl.com")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Should_Not_Have_Error_When_DemoUrl_Is_Valid(string url)
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            DemoUrl = url,
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.DemoUrl);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("htp://invalid")]
+    public void Should_Have_Error_When_DemoUrl_Is_Invalid(string url)
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            DemoUrl = url,
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.DemoUrl)
+            .WithErrorMessage("DemoUrl must be a valid URL or empty.");
+    }
+
+    [Theory]
+    [InlineData("http://validurl.com")]
+    [InlineData("https://validurl.com")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Should_Not_Have_Error_When_RepoUrl_Is_Valid(string url)
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            RepoUrl = url,
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.RepoUrl);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("htp://invalid")]
+    public void Should_Have_Error_When_RepoUrl_Is_Invalid(string url)
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            RepoUrl = url,
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.RepoUrl)
+            .WithErrorMessage("RepoUrl must be a valid URL or empty.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Translations_Is_Empty()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            Translations = new List<ProjectTranslationDto>(),
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Translations)
+            .WithErrorMessage("At least one translation is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_SkillIds_Contains_Empty()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.Empty }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("SkillIds[0]")
+            .WithErrorMessage("At least one skill is required.");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_Model()
+    {
+        var model = new UpdateProjectCommand
+        {
+            Id = Guid.NewGuid(),
+            Slug = "valid-slug",
+            DemoUrl = "https://validurl.com",
+            RepoUrl = "https://validrepo.com",
+            Translations = new List<ProjectTranslationDto> { new ProjectTranslationDto { LanguageCode = "en", Title = "Title" } },
+            SkillIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
Introduce unit test coverage for all handlers, validators, mappers, and test data factories associated with `Projects`. Includes tests for commands like `CreateProject`, `UpdateProject`, and `DeleteProject`, queries like `GetProjects` and `GetProjectById`, and their related DTOs and mapping logic.