### PR TITLE
Refactor and standardize test data setup across `Handlers`, `Mappers`…

### DIFF
--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/AnalyticsTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/AnalyticsTestDataFactory.cs
@@ -1,3 +1,4 @@
+using PersonalSite.Application.Features.Analytics.AnalyticsEvent.Commands.TrackAnalyticsEvent;
 using PersonalSite.Application.Features.Analytics.AnalyticsEvent.Dtos;
 using PersonalSite.Domain.Entities.Analytics;
 
@@ -36,4 +37,20 @@ public static class AnalyticsTestDataFactory
         CreatedAt = e.CreatedAt,
         AdditionalDataJson = e.AdditionalDataJson
     };
+    
+    public static TrackAnalyticsEventCommand CreateTrackAnalyticsEventCommand(
+        string eventType = "PageView",
+        string pageSlug = "/home",
+        string? referrer = "https://google.com",
+        string? userAgent = "Mozilla/5.0",
+        string? additionalDataJson = "{\"source\":\"ad\"}")
+    {
+        return new TrackAnalyticsEventCommand(
+            EventType: eventType,
+            PageSlug: pageSlug,
+            Referrer: referrer,
+            UserAgent: userAgent,
+            AdditionalDataJson: additionalDataJson
+        );
+    }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/BlogPostTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/BlogPostTestDataFactory.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using PersonalSite.Application.Features.Blogs.Blog.Commands.CreateBlogPost;
+using PersonalSite.Application.Features.Blogs.Blog.Commands.PublishBlogPost;
+using PersonalSite.Application.Features.Blogs.Blog.Commands.UpdateBlogPost;
 using PersonalSite.Application.Features.Blogs.Blog.Dtos;
 using PersonalSite.Domain.Entities.Blog;
 using PersonalSite.Domain.Entities.Common;
@@ -137,8 +139,8 @@ public static class BlogPostTestDataFactory
             Slug: slug,
             CoverImage: "cover.jpg",
             IsPublished: isPublished,
-            Translations: translations ?? new List<BlogPostTranslationDto>
-            {
+            Translations: translations ??
+            [
                 new BlogPostTranslationDto
                 {
                     Id = Guid.NewGuid(),
@@ -150,15 +152,15 @@ public static class BlogPostTestDataFactory
                     MetaDescription = "MetaDesc",
                     OgImage = "og.jpg"
                 }
-            },
-            Tags: tags ?? new List<BlogPostTagDto>
-            {
+            ],
+            Tags: tags ??
+            [
                 new BlogPostTagDto
                 {
                     Id = Guid.NewGuid(),
                     Name = "Tech"
                 }
-            }
+            ]
         );
     }
     
@@ -190,6 +192,82 @@ public static class BlogPostTestDataFactory
         {
             Id = id ?? Guid.NewGuid(),
             Name = name
+        };
+    }
+    
+    public static BlogPost CreateUnpublishedBlogPost(Guid? id = null)
+    {
+        return CreateBlogPost(
+            postId: id,
+            isPublished: false,
+            publishedAt: null
+        );
+    }
+
+    public static BlogPost CreatePublishedBlogPost(Guid? id = null, DateTime? publishedAt = null)
+    {
+        return CreateBlogPost(
+            postId: id,
+            isPublished: true,
+            publishedAt: publishedAt ?? DateTime.UtcNow
+        );
+    }
+    
+    public static PublishBlogPostCommand CreatePublishCommand(Guid id, bool isPublished = true, DateTime? publishDate = null)
+    {
+        return new PublishBlogPostCommand
+        {
+            Id = id,
+            IsPublished = isPublished,
+            PublishDate = publishDate ?? DateTime.UtcNow
+        };
+    }
+    
+    public static UpdateBlogPostCommand CreateValidUpdateCommand(
+        Guid id = default, 
+        string slug = "new-slug", 
+        Guid? tagId = null,
+        List<BlogPostTranslationDto>? translations = null)
+    {
+        translations ??= [CreateTranslationDto()];
+        
+        return new UpdateBlogPostCommand(
+            Id: id,
+            Slug: slug,
+            CoverImage: "new-cover.jpg",
+            IsDeleted: true,
+            Translations: translations,
+            Tags: [CreateTagDto(tagId ?? Guid.NewGuid())]
+        );
+    }
+
+    public static BlogPostTranslation CreateTranslation(string code, Guid blogPostId)
+    {
+        var language = CommonTestDataFactory.CreateLanguage(code);
+        return new BlogPostTranslation
+        {
+            Id = Guid.NewGuid(),
+            BlogPostId = blogPostId,
+            LanguageId = language.Id,
+            Language = language,
+            Title = $"Title {code}",
+            Excerpt = $"Excerpt {code}",
+            Content = $"Content {code}",
+            MetaTitle = $"Meta {code}",
+            MetaDescription = $"Desc {code}",
+            OgImage = $"og_{code}.jpg"
+        };
+    }
+
+    public static BlogPost CreateSimpleBlogPost(Guid? id = null, string slug = "old-slug")
+    {
+        return new BlogPost
+        {
+            Id = id ?? Guid.NewGuid(),
+            Slug = slug,
+            CoverImage = "old-cover.jpg",
+            IsDeleted = false,
+            CreatedAt = DateTime.UtcNow.AddDays(-10)
         };
     }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/CommonTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/CommonTestDataFactory.cs
@@ -1,7 +1,13 @@
 using System.Globalization;
+using PersonalSite.Application.Features.Common.Language.Commands.CreateLanguage;
+using PersonalSite.Application.Features.Common.Language.Commands.UpdateLanguage;
 using PersonalSite.Application.Features.Common.Language.Dtos;
 using PersonalSite.Application.Features.Common.LogEntries.Dtos;
+using PersonalSite.Application.Features.Common.Resume.Commands.CreateResume;
+using PersonalSite.Application.Features.Common.Resume.Commands.UpdateResume;
 using PersonalSite.Application.Features.Common.Resume.Dtos;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.CreateSocialMediaLink;
+using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.UpdateSocialMediaLink;
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
 using PersonalSite.Domain.Entities.Common;
 
@@ -27,6 +33,18 @@ public static class CommonTestDataFactory
             Code = language.Code,
             Name = language.Name
         };
+    }
+
+    public static CreateLanguageCommand CreateCreateLanguageCommand(string code = "en", string name = "English")
+    {
+        return new CreateLanguageCommand(code, name);
+    }
+
+    public static UpdateLanguageCommand CreateUpdateLanguageCommand(Guid id = default, string code = "en",
+        string name = "English")
+    {
+        if (id == Guid.Empty) id = Guid.NewGuid();
+        return new UpdateLanguageCommand(id, code, name);   
     }
     
     public static LogEntry CreateLogEntry(
@@ -90,14 +108,33 @@ public static class CommonTestDataFactory
             IsActive = entity.IsActive
         };
     }
+
+    public static CreateResumeCommand CreateCreateResumeCommand(string fileUrl = "https://example.com/resume.pdf",
+        string fileName = "resume.pdf", bool isActive = true)
+    {
+        return new CreateResumeCommand(fileUrl, fileName, isActive);
+    }
+
+    public static UpdateResumeCommand CreateUpdateResumeCommand(
+        Guid id = default, string fileUrl = "https://example.com/resume.pdf",
+        string fileName = "resume.pdf", bool isActive = true)
+    {
+        if (id == Guid.Empty) id = Guid.NewGuid();
+        return new UpdateResumeCommand(id, fileUrl, fileName, isActive);  
+    }
     
-    public static SocialMediaLink CreateSocialMediaLink(Guid? id = null) => new()
+    public static SocialMediaLink CreateSocialMediaLink(
+        Guid? id = null,
+        string platform = "Twitter",
+        string url = "https://twitter.com/example",
+        short displayOrder = 1,
+        bool isActive = true) => new()
     {
         Id = id ?? Guid.NewGuid(),
-        Platform = "Twitter",
-        Url = "https://twitter.com/example",
-        DisplayOrder = 1,
-        IsActive = true
+        Platform = platform,
+        Url = url,
+        DisplayOrder = displayOrder,
+        IsActive = isActive
     };
 
     public static SocialMediaLinkDto MapToDto(SocialMediaLink entity) => new()
@@ -108,4 +145,26 @@ public static class CommonTestDataFactory
         DisplayOrder = entity.DisplayOrder,
         IsActive = entity.IsActive
     };
+
+    public static CreateSocialMediaLinkCommand CreateCreateSocialMediaLinkCommand(
+        string platform = "Facebook",
+        string url = "https://facebook.com/example",
+        int displayOrder = 1,
+        bool isActive = true
+    )
+    {
+        return new CreateSocialMediaLinkCommand(platform, url, displayOrder, isActive);
+    }
+
+    public static UpdateSocialMediaLinkCommand CreateUpdateSocialMediaLinkCommand(
+        Guid id = default,
+        string platform = "Facebook",
+        string url = "https://facebook.com/example",
+        int displayOrder = 1,
+        bool isActive = true
+    )
+    {
+        if (id == Guid.Empty) id = Guid.NewGuid();
+        return new UpdateSocialMediaLinkCommand(id, platform, url, displayOrder, isActive);
+    }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ContactTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ContactTestDataFactory.cs
@@ -1,3 +1,5 @@
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.SendContactMessage;
+using PersonalSite.Application.Features.Contact.ContactMessages.Commands.UpdateContactMessagesReadStatus;
 using PersonalSite.Application.Features.Contact.ContactMessages.Dtos;
 using PersonalSite.Domain.Entities.Contact;
 
@@ -42,5 +44,24 @@ public class ContactTestDataFactory
             CreatedAt = entity.CreatedAt,
             IsRead = entity.IsRead
         };
+    }
+
+    public static SendContactMessageCommand CreateSendContactMessageCommand(
+        string name = "John", 
+        string email = "Doe", 
+        string subject = "Subject", 
+        string message = "Message")
+    {
+        return new SendContactMessageCommand(name, email, subject, message)
+        {
+            IpAddress = "127.0.0.1",
+            UserAgent = "TestAgent"       
+        };
+    }
+
+    public static UpdateContactMessagesReadStatusCommand CreateUpdateContactMessagesReadStatusCommand(
+        List<Guid> ids, bool isRead = true)
+    {
+        return new UpdateContactMessagesReadStatusCommand(ids, isRead);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/PageTestDataFactory.cs
@@ -1,3 +1,5 @@
+using PersonalSite.Application.Features.Pages.Page.Commands.CreatePage;
+using PersonalSite.Application.Features.Pages.Page.Commands.UpdatePage;
 using PersonalSite.Application.Features.Pages.Page.Dtos;
 using PersonalSite.Domain.Entities.Pages;
 using PersonalSite.Domain.Entities.Translations;
@@ -87,5 +89,69 @@ public class PageTestDataFactory
         }
 
         return dto;
+    }
+
+    public static PageTranslationDto CreatePageTranslationDto(
+        string languageCode = "en",
+        string title = "Test",
+        string description = "Test description",
+        string metaTitle = "Test",
+        string metaDescription = "Test",
+        string ogImage = "image.png",
+        Dictionary<string, string>? data = null)
+    {
+        return new PageTranslationDto
+        {
+            Id = Guid.NewGuid(),
+            LanguageCode = languageCode,
+            Title = title,
+            Description = description,
+            MetaTitle = metaTitle,
+            MetaDescription = metaDescription,
+            OgImage = ogImage,
+            Data = data ?? new Dictionary<string, string>()
+        };
+    }
+    
+    
+    public static CreatePageCommand CreateCreatePageCommand(string key = "about") => new(
+        key,
+        [
+            new PageTranslationDto
+            {
+                LanguageCode = "en",
+                Title = "About",
+                Description = "About page",
+                MetaTitle = "About Meta",
+                MetaDescription = "About Meta Description",
+                OgImage = "og-about.png",
+                Data = new Dictionary<string, string> { ["content"] = "Welcome!" }
+            }
+        ]
+    );
+
+    public static UpdatePageCommand CreateUpdatePageCommand(Page page)
+    {
+        return new UpdatePageCommand(
+            page.Id,
+            page.Key,
+            page.Translations.Select(t => new PageTranslationDto
+            {
+                LanguageCode = t.Language.Code,
+                Title = "Updated Title",
+                Data = t.Data,
+                Description = t.Description,
+                MetaTitle = t.MetaTitle,
+                MetaDescription = t.MetaDescription,
+                OgImage = t.OgImage
+            }).ToList());
+    }
+
+    public static UpdatePageCommand CreateUpdatePageCommand(Guid id, string key, List<PageTranslationDto> translations)
+    {
+        return new UpdatePageCommand(
+            id,
+            key,
+            translations);       
     }
 }

--- a/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ProjectTestDataFactory.cs
+++ b/tests/PersonalSite.Application.Tests/Fixtures/TestDataFactories/ProjectTestDataFactory.cs
@@ -1,3 +1,5 @@
+using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
+using PersonalSite.Application.Features.Projects.Project.Commands.UpdateProject;
 using PersonalSite.Application.Features.Projects.Project.Dtos;
 using PersonalSite.Application.Features.Skills.SkillCategories.Dtos;
 using PersonalSite.Application.Features.Skills.Skills.Dtos;
@@ -152,5 +154,79 @@ public static class ProjectTestDataFactory
                 }
             }).ToList()
         };
+    }
+
+    public static ProjectTranslationDto CreateTranslationDto(
+        Guid? id,
+        Guid? projectId,
+        string code = "en",
+        string title = "Title",
+        string shortDescription = "Short description",
+        Dictionary<string, string>? descriptionSections = null,
+        string metaTitle = "Title",
+        string metaDescription = "Description",
+        string ogImage = "image.png")
+    {
+        return new ProjectTranslationDto
+        {
+            Id = id ?? Guid.NewGuid(),
+            LanguageCode = code,
+            ProjectId = projectId ?? Guid.NewGuid(),
+            Title = title,
+            ShortDescription = shortDescription,
+            DescriptionSections = descriptionSections ?? [],
+            MetaTitle = metaTitle,
+            MetaDescription = metaDescription,
+            OgImage = ogImage       
+        };
+    }
+
+    public static CreateProjectCommand CreateCreateProjectCommand(List<ProjectTranslationDto>? translations,
+        List<Guid>? skillIds, string slug = "sample-project") => new()
+    {
+        Slug = slug,
+        Translations = translations ?? new List<ProjectTranslationDto>(),
+        SkillIds = skillIds ?? new List<Guid>()       
+    };
+    
+    public static (
+        UpdateProjectCommand Command,
+        Project Project,
+        Language Language,
+        Guid SkillId) CreateValidUpdateProjectCommandAndEntities()
+    {
+        var projectId = Guid.NewGuid();
+        var skillId = Guid.NewGuid();
+        var language = CommonTestDataFactory.CreateLanguage();
+
+        var translationDto = ProjectTestDataFactory.CreateTranslationDto(
+            id: null,
+            projectId: projectId,
+            code: language.Code,
+            title: "Title",
+            shortDescription: "Short desc",
+            descriptionSections: new(),
+            metaTitle: "Meta",
+            metaDescription: "Meta desc",
+            ogImage: "og.png"
+        );
+
+        var command = new UpdateProjectCommand
+        {
+            Id = projectId,
+            Slug = "updated-slug",
+            CoverImage = "new-image.png",
+            DemoUrl = "demo.com",
+            RepoUrl = "repo.com",
+            SkillIds = [skillId],
+            Translations = [translationDto]
+        };
+
+        var project = ProjectTestDataFactory.CreateProject(id: projectId, lanuageCode: language.Code);
+        project.Slug = "old-slug";
+        project.ProjectSkills.Clear();
+        project.Translations.Clear();
+
+        return (command, project, language, skillId);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Analytics/AnalyticsEvent/TrackAnalyticsEventCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Analytics/AnalyticsEvent/TrackAnalyticsEventCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Analytics.AnalyticsEvent.Commands.TrackAnalyticsEvent;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Analytics;
 
 namespace PersonalSite.Application.Tests.Handlers.Analytics.AnalyticsEvent;
@@ -24,13 +25,7 @@ public class TrackAnalyticsEventCommandHandlerTests
     public async Task Handle_ShouldTrackEvent_WhenDataIsValid()
     {
         // Arrange
-        var command = new TrackAnalyticsEventCommand(
-            EventType: "PageView",
-            PageSlug: "/home",
-            Referrer: "https://google.com",
-            UserAgent: "Mozilla/5.0",
-            AdditionalDataJson: "{\"source\":\"ad\"}"
-        );
+        var command = AnalyticsTestDataFactory.CreateTrackAnalyticsEventCommand();
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -53,12 +48,11 @@ public class TrackAnalyticsEventCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_WhenExceptionIsThrown()
     {
         // Arrange
-        var command = new TrackAnalyticsEventCommand(
-            EventType: "PageView",
-            PageSlug: "/error",
-            Referrer: null,
-            UserAgent: null,
-            AdditionalDataJson: null
+        var command = AnalyticsTestDataFactory.CreateTrackAnalyticsEventCommand(
+            pageSlug: "/error",
+            referrer: null,
+            userAgent: null,
+            additionalDataJson: null
         );
 
         _repositoryMock.Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Analytics.AnalyticsEvent>(), It.IsAny<CancellationToken>()))

--- a/tests/PersonalSite.Application.Tests/Handlers/Blogs/BlogPosts/GetBlogPostByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Blogs/BlogPosts/GetBlogPostByIdQueryHandlerTests.cs
@@ -12,18 +12,17 @@ public class GetBlogPostByIdQueryHandlerTests
 {
     private readonly Mock<IBlogPostRepository> _repositoryMock;
     private readonly Mock<IAdminMapper<BlogPost, BlogPostAdminDto>> _mapperMock;
-    private readonly Mock<ILogger<GetBlogPostByIdQueryHandler>> _loggerMock;
     private readonly GetBlogPostByIdQueryHandler _handler;
 
     public GetBlogPostByIdQueryHandlerTests()
     {
         _repositoryMock = new Mock<IBlogPostRepository>();
         _mapperMock = new Mock<IAdminMapper<BlogPost, BlogPostAdminDto>>();
-        _loggerMock = new Mock<ILogger<GetBlogPostByIdQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetBlogPostByIdQueryHandler>>();
 
         _handler = new GetBlogPostByIdQueryHandler(
             _repositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _mapperMock.Object
         );
     }
@@ -86,16 +85,5 @@ public class GetBlogPostByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error occurred while getting blog post by id");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error occurred while getting blog post by id")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()
-            ),
-            Times.Once
-        );
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Blogs/BlogPosts/UpdateBlogPostCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Blogs/BlogPosts/UpdateBlogPostCommandHandlerTests.cs
@@ -1,5 +1,4 @@
 using PersonalSite.Application.Features.Blogs.Blog.Commands.UpdateBlogPost;
-using PersonalSite.Application.Features.Blogs.Blog.Dtos;
 using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Blog;
 using PersonalSite.Domain.Entities.Common;
@@ -40,38 +39,21 @@ public class UpdateBlogPostCommandHandlerTests
     {
         // Arrange
         var blogPostId = Guid.NewGuid();
-        var languageId = Guid.NewGuid();
-        var existingTagId = Guid.NewGuid();
-    
-        var blogPost = new BlogPost
-        {
-            Id = blogPostId,
-            Slug = "old-slug",
-            CoverImage = "old-cover.jpg",
-            IsDeleted = false,
-            CreatedAt = DateTime.UtcNow.AddDays(-10)
-        };
-    
-        var language = new Language { Id = languageId, Code = "en" };
-    
-        var translationDto = new BlogPostTranslationDto
-        {
-            Id = Guid.NewGuid(),
-            LanguageCode = "en",
-            Title = "Updated Title",
-            Excerpt = "Updated Excerpt",
-            Content = "Updated Content",
-            MetaTitle = "Meta",
-            MetaDescription = "MetaDesc",
-            OgImage = "og.jpg"
-        };
-    
-        var tagDto = new BlogPostTagDto
-        {
-            Id = existingTagId,
-            Name = "Tech"
-        };
-    
+        var language = CommonTestDataFactory.CreateLanguage();
+        var tagId = Guid.NewGuid();
+
+        var blogPost = BlogPostTestDataFactory.CreateSimpleBlogPost(blogPostId);
+
+        var translationDto = BlogPostTestDataFactory.CreateTranslationDto( 
+            title: "Updated Title", 
+            excerpt: "Updated Excerpt", 
+            content: "Updated Content", 
+            metaTitle: "Meta", 
+            metaDescription: "MetaDesc", 
+            ogImage: "og.jpg");
+
+        var tagDto = BlogPostTestDataFactory.CreateTagDto(tagId);
+
         var request = new UpdateBlogPostCommand(
             Id: blogPostId,
             Slug: "new-slug",
@@ -80,21 +62,12 @@ public class UpdateBlogPostCommandHandlerTests
             Translations: [translationDto],
             Tags: [tagDto]
         );
-    
-        var existingTranslation = new BlogPostTranslation
-        {
-            Id = Guid.NewGuid(),
-            BlogPostId = blogPostId,
-            LanguageId = languageId,
-            Language = language
-        };
-    
-        var existingPostTag = new PostTag
-        {
-            Id = Guid.NewGuid(),
-            BlogPostId = blogPostId,
-            BlogPostTagId = Guid.NewGuid()
-        };
+
+        var existingTranslation = BlogPostTestDataFactory.CreateTranslation("en", blogPostId);
+        existingTranslation.LanguageId = language.Id;
+        existingTranslation.Language = language;
+
+        var existingPostTag = BlogPostTestDataFactory.CreatePostTag(blogPostId);
     
         _blogPostRepoMock.Setup(r => r.GetByIdAsync(blogPostId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blogPost);
@@ -111,8 +84,8 @@ public class UpdateBlogPostCommandHandlerTests
         _postTagRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPostId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([existingPostTag]);
     
-        _tagRepoMock.Setup(r => r.GetByIdAsync(existingTagId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlogPostTag { Id = existingTagId, Name = "Tech" });
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlogPostTag { Id = tagId, Name = "Tech" });
     
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -129,14 +102,7 @@ public class UpdateBlogPostCommandHandlerTests
     public async Task Handle_ShouldFail_WhenBlogPostDoesNotExist()
     {
         // Arrange
-        var request = new UpdateBlogPostCommand(
-            Id: Guid.NewGuid(),
-            Slug: "slug",
-            CoverImage: "cover.jpg",
-            IsDeleted: false,
-            Translations: [],
-            Tags: []
-        );
+        var request = BlogPostTestDataFactory.CreateValidUpdateCommand(Guid.NewGuid());
 
         _blogPostRepoMock
             .Setup(r => r.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
@@ -154,20 +120,9 @@ public class UpdateBlogPostCommandHandlerTests
     public async Task Handle_ShouldFail_WhenSlugIsNotAvailable()
     {
         // Arrange
-        var blogPost = new BlogPost
-        {
-            Id = Guid.NewGuid(),
-            Slug = "original-slug"
-        };
+        var blogPost = BlogPostTestDataFactory.CreateBlogPost();
 
-        var request = new UpdateBlogPostCommand(
-            Id: blogPost.Id,
-            Slug: "new-slug", // different slug
-            CoverImage: "image.jpg",
-            IsDeleted: false,
-            Translations: [],
-            Tags: []
-        );
+        var request = BlogPostTestDataFactory.CreateValidUpdateCommand(blogPost.Id);
 
         _blogPostRepoMock.Setup(r => r.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blogPost);
@@ -186,35 +141,15 @@ public class UpdateBlogPostCommandHandlerTests
     [Fact]
     public async Task Handle_ShouldFail_WhenLanguageDoesNotExist()
     {
-        // Arrange
-        var blogPost = new BlogPost
-        {
-            Id = Guid.NewGuid(),
-            Slug = "slug"
-        };
-
-        var translation = new BlogPostTranslationDto
-        {
-            LanguageCode = "xx", // not found
-            Title = "T", Excerpt = "E", Content = "C",
-            MetaTitle = "M", MetaDescription = "MD", OgImage = "og.jpg"
-        };
-
-        var request = new UpdateBlogPostCommand(
-            Id: blogPost.Id,
-            Slug: "slug",
-            CoverImage: "img.jpg",
-            IsDeleted: false,
-            Translations: [translation],
-            Tags: []
-        );
+        var blogPost = BlogPostTestDataFactory.CreateSimpleBlogPost(slug: "slug");
+        var translation = BlogPostTestDataFactory.CreateTranslationDto("xx");
+        var request = BlogPostTestDataFactory.CreateValidUpdateCommand(blogPost.Id, "slug", 
+            translations: [translation]);
 
         _blogPostRepoMock.Setup(r => r.GetByIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blogPost);
-
         _languageRepoMock.Setup(r => r.GetByCodeAsync("xx", It.IsAny<CancellationToken>()))
             .ReturnsAsync((Language?)null);
-
         _translationRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
@@ -229,76 +164,51 @@ public class UpdateBlogPostCommandHandlerTests
     [Fact]
     public async Task Handle_ShouldRemoveMissingTranslationsAndTags()
     {
-        // Arrange
+        //Arrange
         var blogPostId = Guid.NewGuid();
-        var languageId = Guid.NewGuid();
-        var tagId = Guid.NewGuid();
 
-        var blogPost = new BlogPost { Id = blogPostId, Slug = "slug" };
+        var deTranslation = BlogPostTestDataFactory.CreateTranslation("de", blogPostId);
+        var existingTag = BlogPostTestDataFactory.CreatePostTag(blogPostId);
 
-        var existingTranslation = new BlogPostTranslation
-        {
-            Id = Guid.NewGuid(),
-            BlogPostId = blogPostId,
-            LanguageId = languageId,
-            Language = new Language { Id = languageId, Code = "de" }
-        };
+        var blogPost = BlogPostTestDataFactory.CreateSimpleBlogPost(blogPostId);
+        blogPost.Translations = [deTranslation];
+        blogPost.PostTags = [existingTag];
 
-        var existingTag = new PostTag
-        {
-            Id = Guid.NewGuid(),
-            BlogPostId = blogPostId,
-            BlogPostTagId = tagId
-        };
+        var enTranslationDto = BlogPostTestDataFactory.CreateTranslationDto();
 
-        var translationDto = new BlogPostTranslationDto
-        {
-            LanguageCode = "en", Title = "", Excerpt = "", Content = "", MetaTitle = "", MetaDescription = "", OgImage = ""
-        };
+        var request = BlogPostTestDataFactory.CreateValidUpdateCommand(
+            id: blogPostId, slug: "slug", translations: [enTranslationDto]);
 
-        var request = new UpdateBlogPostCommand(
-            Id: blogPostId,
-            Slug: "slug",
-            CoverImage: "img",
-            IsDeleted: false,
-            Translations: [translationDto], // Only "en", so "de" should be removed
-            Tags: [] // Tag should be removed
-        );
-
-        _blogPostRepoMock.Setup(r => r.GetByIdAsync(blogPostId, It.IsAny<CancellationToken>()))
+        _blogPostRepoMock.Setup(r => r.GetByIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blogPost);
 
         _blogPostRepoMock.Setup(r => r.IsSlugAvailableAsync("slug", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        _translationRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPostId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([existingTranslation]);
+        _translationRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([deTranslation]);
 
-        _postTagRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPostId, It.IsAny<CancellationToken>()))
+        _postTagRepoMock.Setup(r => r.GetByBlogPostIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([existingTag]);
 
         _languageRepoMock.Setup(r => r.GetByCodeAsync("en", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Language { Id = Guid.NewGuid(), Code = "en" });
+            .ReturnsAsync(CommonTestDataFactory.CreateLanguage());
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        _translationRepoMock.Verify(r => r.Remove(existingTranslation), Times.Once);
+        _translationRepoMock.Verify(r => r.Remove(deTranslation), Times.Once);
         _postTagRepoMock.Verify(r => r.Remove(existingTag), Times.Once);
     }
 
     [Fact]
     public async Task Handle_ShouldReturnFailure_WhenExceptionIsThrown()
     {
-        // Arrange
-        var blogPost = new BlogPost { Id = Guid.NewGuid(), Slug = "slug" };
-
-        var request = new UpdateBlogPostCommand(
-            blogPost.Id,
-            "slug", "img.jpg", false, [], []
-        );
+        var blogPost = BlogPostTestDataFactory.CreateSimpleBlogPost();
+        
+        var request = BlogPostTestDataFactory.CreateValidUpdateCommand(blogPost.Id);
 
         _blogPostRepoMock.Setup(r => r.GetByIdAsync(blogPost.Id, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("boom"));

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Language/CreateLanguageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Language/CreateLanguageCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.Language.Commands.CreateLanguage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.Language;
@@ -19,7 +20,7 @@ public class CreateLanguageCommandHandlerTests
     public async Task Handle_ShouldCreateLanguage_WhenCodeDoesNotExist()
     {
         // Arrange
-        var command = new CreateLanguageCommand("en", "English");
+        var command = CommonTestDataFactory.CreateCreateLanguageCommand();
         _repositoryMock.Setup(r => r.ExistsByCodeAsync(command.Code, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _repositoryMock.Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.Language>(), It.IsAny<CancellationToken>()))
@@ -45,7 +46,7 @@ public class CreateLanguageCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_WhenCodeAlreadyExists()
     {
         // Arrange
-        var command = new CreateLanguageCommand("en", "English");
+        var command = CommonTestDataFactory.CreateCreateLanguageCommand();
         _repositoryMock.Setup(r => r.ExistsByCodeAsync(command.Code, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
@@ -73,7 +74,7 @@ public class CreateLanguageCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_OnException()
     {
         // Arrange
-        var command = new CreateLanguageCommand("en", "English");
+        var command = CommonTestDataFactory.CreateCreateLanguageCommand();
         var exception = new Exception("Database failure");
         _repositoryMock.Setup(r => r.ExistsByCodeAsync(command.Code, It.IsAny<CancellationToken>()))
             .ThrowsAsync(exception);

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Language/DeleteLanguageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Language/DeleteLanguageCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.Language.Commands.DeleteLanguage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.Language;
@@ -22,11 +23,7 @@ public class DeleteLanguageCommandHandlerTests
     public async Task Handle_ShouldSoftDeleteLanguage_WhenLanguageExists()
     {
         // Arrange
-        var language = new Domain.Entities.Common.Language
-        {
-            Id = Guid.NewGuid(),
-            IsDeleted = false
-        };
+        var language = CommonTestDataFactory.CreateLanguage();
         var command = new DeleteLanguageCommand(language.Id);
 
         _repositoryMock.Setup(r => r.GetByIdAsync(language.Id, It.IsAny<CancellationToken>()))
@@ -92,14 +89,5 @@ public class DeleteLanguageCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error occurred while deleting language");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error occurred while deleting language")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), 
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Language/GetLanguageByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Language/GetLanguageByIdQueryHandlerTests.cs
@@ -59,13 +59,6 @@ public class GetLanguageByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Language not found.");
-        _loggerMock.Verify(l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Language with ID")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -84,12 +77,5 @@ public class GetLanguageByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error getting language by id.");
-        _loggerMock.Verify(l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error getting language by id.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Language/GetLanguagesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Language/GetLanguagesQueryHandlerTests.cs
@@ -28,7 +28,8 @@ public class GetLanguagesQueryHandlerTests
             CommonTestDataFactory.CreateLanguage("fr")
         };
 
-        var languageDtos = languages.Select(l => new LanguageDto { Id = l.Id, Code = l.Code, Name = l.Name }).ToList();
+        var languageDtos = languages.Select(
+            CommonTestDataFactory.MapToDto).ToList();
 
         _repositoryMock.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(languages);
@@ -62,13 +63,5 @@ public class GetLanguagesQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(l => l.Log(
-            LogLevel.Error,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error occurred while retrieving languages.")),
-            exception,
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Language/UpdateLanguageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Language/UpdateLanguageCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.Language.Commands.UpdateLanguage;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.Language;
@@ -7,25 +8,24 @@ public class UpdateLanguageCommandHandlerTests
 {
     private readonly Mock<ILanguageRepository> _repositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ILogger<UpdateLanguageCommandHandler>> _loggerMock;
     private readonly UpdateLanguageCommandHandler _handler;
 
     public UpdateLanguageCommandHandlerTests()
     {
         _repositoryMock = new Mock<ILanguageRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _loggerMock = new Mock<ILogger<UpdateLanguageCommandHandler>>();
+        var loggerMock = new Mock<ILogger<UpdateLanguageCommandHandler>>();
         _handler = new UpdateLanguageCommandHandler(
             _repositoryMock.Object,
             _unitOfWorkMock.Object,
-            _loggerMock.Object);
+            loggerMock.Object);
     }
 
     [Fact]
     public async Task Handle_ShouldReturnFailure_WhenLanguageNotFound()
     {
         // Arrange
-        var command = new UpdateLanguageCommand(Guid.NewGuid(), "en", "English");
+        var command = CommonTestDataFactory.CreateUpdateLanguageCommand();
         _repositoryMock.Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Domain.Entities.Common.Language?)null);
 
@@ -36,14 +36,6 @@ public class UpdateLanguageCommandHandlerTests
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Language not found.");
 
-        _loggerMock.Verify(l => l.Log(
-            LogLevel.Warning,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Language not found.")),
-            null,
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
-
         _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Common.Language>(), It.IsAny<CancellationToken>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -52,14 +44,9 @@ public class UpdateLanguageCommandHandlerTests
     public async Task Handle_ShouldUpdateLanguage_WhenLanguageExists()
     {
         // Arrange
-        var language = new Domain.Entities.Common.Language
-        {
-            Id = Guid.NewGuid(),
-            Code = "fr",
-            Name = "French"
-        };
+        var language = CommonTestDataFactory.CreateLanguage("fr");
 
-        var command = new UpdateLanguageCommand(language.Id, "en", "English");
+        var command = CommonTestDataFactory.CreateUpdateLanguageCommand(language.Id);
 
         _repositoryMock.Setup(r => r.GetByIdAsync(language.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(language);
@@ -86,7 +73,7 @@ public class UpdateLanguageCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_OnException()
     {
         // Arrange
-        var command = new UpdateLanguageCommand(Guid.NewGuid(), "en", "English");
+        var command = CommonTestDataFactory.CreateUpdateLanguageCommand();
         _repositoryMock.Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Database error"));
 
@@ -96,13 +83,5 @@ public class UpdateLanguageCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error occurred while updating language");
-
-        _loggerMock.Verify(l => l.Log(
-            LogLevel.Error,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error occurred while updating language")),
-            It.IsAny<Exception>(),
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/DeleteLogsCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/DeleteLogsCommandHandlerTests.cs
@@ -75,13 +75,5 @@ public class DeleteLogsCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Failed to delete log entries.");
-        _loggerMock.Verify(
-            x => x.Log<It.IsAnyType>(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Failed to delete log entries.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/GetLogEntriesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/LogEntries/GetLogEntriesQueryHandlerTests.cs
@@ -38,17 +38,7 @@ public class GetLogEntriesQueryHandlerTests
                 query.Page, query.PageSize, query.LevelFilter, query.SourceContextFilter, query.From, query.To, It.IsAny<CancellationToken>()))
             .ReturnsAsync(pagedResult);
 
-        var mappedDtos = logEntities.Select(e => new LogEntryDto
-        {
-            Id = e.Id,
-            Timestamp = e.Timestamp,
-            Level = e.Level,
-            Message = e.Message,
-            MessageTemplate = e.MessageTemplate,
-            Exception = e.Exception,
-            Properties = e.Properties,
-            SourceContext = e.SourceContext
-        }).ToList();
+        var mappedDtos = logEntities.Select(CommonTestDataFactory.MapToDto).ToList();
 
         _mapperMock.Setup(m => m.MapToDtoList(logEntities)).Returns(mappedDtos);
 
@@ -84,14 +74,6 @@ public class GetLogEntriesQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Log entries not found");
-
-        _loggerMock.Verify(l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Log entries not found")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -116,14 +98,5 @@ public class GetLogEntriesQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error getting log entries.");
-
-        _loggerMock.Verify(l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error getting log entries.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
-
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/CreateResumeCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/CreateResumeCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.Resume.Commands.CreateResume;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
@@ -26,7 +27,7 @@ public class CreateResumeCommandHandlerTests
     public async Task Handle_ShouldReturnSuccess_WithNewGuid_WhenResumeCreated()
     {
         // Arrange
-        var command = new CreateResumeCommand("http://file.url/resume.pdf", "resume.pdf", true);
+        var command = CommonTestDataFactory.CreateCreateResumeCommand();
 
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.Resume>(), It.IsAny<CancellationToken>()))
@@ -58,7 +59,7 @@ public class CreateResumeCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_AndLogError_WhenExceptionThrown()
     {
         // Arrange
-        var command = new CreateResumeCommand("url", "file", true);
+        var command = CommonTestDataFactory.CreateCreateResumeCommand("url", "file");
         var exception = new Exception("Database error");
 
         _repositoryMock
@@ -71,14 +72,5 @@ public class CreateResumeCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Failed to create resume.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating resume.")),
-                exception,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/DeleteResumeCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/DeleteResumeCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.Resume.Commands.DeleteResume;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.Resume;
@@ -27,7 +28,7 @@ public class DeleteResumeCommandHandlerTests
     {
         // Arrange
         var resumeId = Guid.NewGuid();
-        var resume = new Domain.Entities.Common.Resume { Id = resumeId };
+        var resume = CommonTestDataFactory.CreateResume();
 
         _repositoryMock
             .Setup(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
@@ -45,7 +46,6 @@ public class DeleteResumeCommandHandlerTests
         _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
         _repositoryMock.Verify(r => r.Remove(resume), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _loggerMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -68,7 +68,6 @@ public class DeleteResumeCommandHandlerTests
         _repositoryMock.Verify(r => r.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()), Times.Once);
         _repositoryMock.Verify(r => r.Remove(It.IsAny<Domain.Entities.Common.Resume>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
-        _loggerMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -88,14 +87,5 @@ public class DeleteResumeCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Failed to delete resume.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error deleting resume.")),
-                exception,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumeByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumeByIdQueryHandlerTests.cs
@@ -84,15 +84,5 @@ public class GetResumeByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error getting resume by id.");
-
-        // Verify that error was logged
-        _loggerMock.Verify(
-            l => l.Log(
-                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error getting resume by id.")),
-                It.Is<Exception>(ex => ex == exception),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/Resume/GetResumesQueryHandlerTests.cs
@@ -92,15 +92,6 @@ public class GetResumesQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Resumes not found");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Resumes not found")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -125,14 +116,5 @@ public class GetResumesQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("An error occurred while getting the resumes.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error getting resumes.")),
-                exception,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SiteInfo/GetSiteInfoQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SiteInfo/GetSiteInfoQueryHandlerTests.cs
@@ -5,7 +5,6 @@ using PersonalSite.Application.Features.Common.SiteInfo.Queries.GetSiteInfo;
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
 using PersonalSite.Application.Tests.Common;
 using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
-using PersonalSite.Domain.Entities.Common;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.SiteInfo;
@@ -99,8 +98,6 @@ public class GetSiteInfoQueryHandlerTests
         result.Value?.Languages.Should().BeEquivalentTo(languageDtos);
         result.Value?.SocialLinks.Should().BeEquivalentTo(socialLinkDtos);
         result.Value?.Resume.Should().BeEquivalentTo(resumeDto);
-
-        _loggerMock.VerifyNoOtherCalls(); // No warnings/errors expected in this successful scenario
     }
 
     [Fact]
@@ -108,7 +105,7 @@ public class GetSiteInfoQueryHandlerTests
     {
         var languages = new List<Domain.Entities.Common.Language>
         {
-            new Domain.Entities.Common.Language { Id = Guid.NewGuid(), Name = "English", IsDeleted = false }
+            CommonTestDataFactory.CreateLanguage()
         };
 
         _languageRepoMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
@@ -130,9 +127,6 @@ public class GetSiteInfoQueryHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value?.SocialLinks.Should().BeEmpty();
         result.Value?.Resume.Should().BeNull();
-
-        _loggerMock.VerifyLog(LogLevel.Warning, "No social links found.", Times.Once());
-        _loggerMock.VerifyLog(LogLevel.Warning, "No active resume found.", Times.Once());
     }
 
     [Fact]
@@ -147,7 +141,5 @@ public class GetSiteInfoQueryHandlerTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.VerifyLog(LogLevel.Error, "Error occurred while getting site info.", Times.Once());
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/CreateSocialMediaLinkCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/CreateSocialMediaLinkCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.CreateSocialMediaLink;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
@@ -27,12 +28,8 @@ public class CreateSocialMediaLinkCommandHandlerTests
     public async Task Handle_ShouldReturnSuccess_WhenCreationIsSuccessful()
     {
         // Arrange
-        var command = new CreateSocialMediaLinkCommand(
-            Platform: "GitHub",
-            Url: "https://github.com/user",
-            DisplayOrder: 1,
-            IsActive: true
-        );
+        var command = CommonTestDataFactory.CreateCreateSocialMediaLinkCommand(
+            "GitHub", "https://github.com/user");
 
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()))
@@ -58,12 +55,8 @@ public class CreateSocialMediaLinkCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_WhenExceptionIsThrown()
     {
         // Arrange
-        var command = new CreateSocialMediaLinkCommand(
-            Platform: "Twitter",
-            Url: "https://twitter.com/user",
-            DisplayOrder: 2,
-            IsActive: true
-        );
+        var command = CommonTestDataFactory.CreateCreateSocialMediaLinkCommand(
+            "Twitter", "https://twitter.com/user", 2);
 
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<Domain.Entities.Common.SocialMediaLink>(), It.IsAny<CancellationToken>()))
@@ -75,15 +68,5 @@ public class CreateSocialMediaLinkCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Failed to create social media link.");
-
-        _loggerMock.Verify(
-            x => x.Log<It.IsAnyType>(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating social media link")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once
-        );
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinkByIdQueryHandlerTests.cs
@@ -1,7 +1,6 @@
 using PersonalSite.Application.Common.Mapping;
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Dtos;
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Queries.GetSocialMediaLinkById;
-using PersonalSite.Application.Tests.Common;
 using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
@@ -57,7 +56,6 @@ public class GetSocialMediaLinkByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Social media link not found.");
-        _loggerMock.VerifyLog(LogLevel.Warning, $"Social media link with ID {id} not found.", Times.Once());
     }
 
     [Fact]
@@ -77,6 +75,5 @@ public class GetSocialMediaLinkByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("DB error");
-        _loggerMock.VerifyLog(LogLevel.Error, "Error occurred while getting social media link by id.", Times.Once());
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinksQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/GetSocialMediaLinksQueryHandlerTests.cs
@@ -68,15 +68,6 @@ public class GetSocialMediaLinksQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Social media links not found");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Social media links not found")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -92,14 +83,5 @@ public class GetSocialMediaLinksQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Failed to get social media links");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error occurred while getting social media links")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/UpdateSocialMediaLinkCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Common/SocialMediaLink/UpdateSocialMediaLinkCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Common.SocialMediaLinks.Commands.UpdateSocialMediaLink;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
 
 namespace PersonalSite.Application.Tests.Handlers.Common.SocialMediaLink;
@@ -7,19 +8,18 @@ public class UpdateSocialMediaLinkCommandHandlerTests
 {
     private readonly Mock<ISocialMediaLinkRepository> _repositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ILogger<UpdateSocialMediaLinkCommandHandler>> _loggerMock;
     private readonly UpdateSocialMediaLinkCommandHandler _handler;
 
     public UpdateSocialMediaLinkCommandHandlerTests()
     {
         _repositoryMock = new Mock<ISocialMediaLinkRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _loggerMock = new Mock<ILogger<UpdateSocialMediaLinkCommandHandler>>();
+        var loggerMock = new Mock<ILogger<UpdateSocialMediaLinkCommandHandler>>();
 
         _handler = new UpdateSocialMediaLinkCommandHandler(
             _repositoryMock.Object,
             _unitOfWorkMock.Object,
-            _loggerMock.Object
+            loggerMock.Object
         );
     }
 
@@ -28,21 +28,19 @@ public class UpdateSocialMediaLinkCommandHandlerTests
     {
         // Arrange
         var id = Guid.NewGuid();
-        var entity = new Domain.Entities.Common.SocialMediaLink
-        {
-            Id = id,
-            Platform = "old",
-            Url = "old-url",
-            DisplayOrder = 1,
-            IsActive = false
-        };
+        var entity = CommonTestDataFactory.CreateSocialMediaLink(
+            id: id,
+            platform: "old",
+            url: "old-url",
+            displayOrder: 1,
+            isActive: false);
 
-        var command = new UpdateSocialMediaLinkCommand(
-            Id: id,
-            Platform: "LinkedIn",
-            Url: "https://linkedin.com/in/me",
-            DisplayOrder: 2,
-            IsActive: true
+        var command = CommonTestDataFactory.CreateUpdateSocialMediaLinkCommand(
+            id: id,
+            platform: "LinkedIn",
+            url: "https://linkedin.com/in/me",
+            displayOrder: 2,
+            isActive: true
         );
 
         _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
@@ -74,12 +72,12 @@ public class UpdateSocialMediaLinkCommandHandlerTests
         _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Domain.Entities.Common.SocialMediaLink?)null);
 
-        var command = new UpdateSocialMediaLinkCommand(
-            Id: id,
-            Platform: "Twitter",
-            Url: "https://twitter.com",
-            DisplayOrder: 1,
-            IsActive: true
+        var command = CommonTestDataFactory.CreateUpdateSocialMediaLinkCommand(
+            id: id,
+            platform: "Twitter",
+            url: "https://twitter.com",
+            displayOrder: 1,
+            isActive: true
         );
 
         // Act
@@ -98,12 +96,12 @@ public class UpdateSocialMediaLinkCommandHandlerTests
     {
         // Arrange
         var id = Guid.NewGuid();
-        var command = new UpdateSocialMediaLinkCommand(
-            Id: id,
-            Platform: "YouTube",
-            Url: "https://youtube.com",
-            DisplayOrder: 5,
-            IsActive: true
+        var command = CommonTestDataFactory.CreateUpdateSocialMediaLinkCommand(
+            id: id,
+            platform: "YouTube",
+            url: "https://youtube.com",
+            displayOrder: 5,
+            isActive: true
         );
 
         _repositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
@@ -115,15 +113,5 @@ public class UpdateSocialMediaLinkCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            x => x.Log<It.IsAnyType>(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Error occurred while updating social media link")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once
-        );
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/DeleteContactMessagesCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/DeleteContactMessagesCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Contact.ContactMessages.Commands.DeleteContactMessages;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Contact;
 using PersonalSite.Domain.Interfaces.Repositories.Contact;
 
@@ -20,8 +21,8 @@ public class DeleteContactMessagesCommandHandlerTests
         var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
         var messages = new List<ContactMessage>
         {
-            new() { Id = ids[0], Name = "Test 1" },
-            new() { Id = ids[1], Name = "Test 2" }
+            ContactTestDataFactory.CreateContactMessage(id: ids[0], name: "Test 1"),
+            ContactTestDataFactory.CreateContactMessage(id: ids[1], name: "Test 2")
         };
 
         _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
@@ -45,7 +46,7 @@ public class DeleteContactMessagesCommandHandlerTests
         var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
         var onlyOneMessage = new List<ContactMessage>
         {
-            new() { Id = ids[0], Name = "Only found" }
+            ContactTestDataFactory.CreateContactMessage(id: ids[0], name: "Only found")
         };
 
         _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
@@ -79,18 +80,5 @@ public class DeleteContactMessagesCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Failed to delete messages.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) =>
-                    state.ToString() != null &&
-                    state.ToString()!.Contains("Error deleting contact messages.")
-                ),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once
-        );
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessageByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/GetContactMessageByIdQueryHandlerTests.cs
@@ -35,7 +35,6 @@ public class GetContactMessageByIdQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().BeEquivalentTo(dto);
-        _loggerMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -55,14 +54,6 @@ public class GetContactMessageByIdQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Contact message not found.");
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Contact message not found")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -82,14 +73,5 @@ public class GetContactMessageByIdQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Error getting contact message by id.");
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) =>
-                    v.ToString()!.Contains("Error getting contact message by id")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/SendContactMessageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/SendContactMessageCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using PersonalSite.Application.Features.Contact.ContactMessages.Commands.SendContactMessage;
 using PersonalSite.Application.Features.Contact.ContactMessages.Events.ContactMessageCreated;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Contact;
 using PersonalSite.Domain.Interfaces.Repositories.Contact;
 
@@ -20,11 +21,9 @@ public class SendContactMessageCommandHandlerTests
     public async Task Handle_ShouldReturnSuccess_AndPublishEvent_WhenValidRequest()
     {
         // Arrange
-        var command = new SendContactMessageCommand("John", "john@example.com", "Hello", "Test message")
-        {
-            IpAddress = "127.0.0.1",
-            UserAgent = "TestAgent"
-        };
+        var command =
+            ContactTestDataFactory.CreateSendContactMessageCommand(
+                "John", "john@example.com", "Hello", "Test message");
 
         var handler = CreateHandler();
 
@@ -52,7 +51,8 @@ public class SendContactMessageCommandHandlerTests
     public async Task Handle_ShouldReturnFailure_WhenExceptionThrown()
     {
         // Arrange
-        var command = new SendContactMessageCommand("John", "john@example.com", "Hello", "Test message");
+        var command = ContactTestDataFactory.CreateSendContactMessageCommand(
+            "John", "john@example.com", "Hello", "Test message");
         _repositoryMock.Setup(r => r.AddAsync(It.IsAny<ContactMessage>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("DB error"));
 
@@ -64,14 +64,5 @@ public class SendContactMessageCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Error creating contact message.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error creating contact message.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Contact/ContactMessages/UpdateContactMessagesReadStatusCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using PersonalSite.Application.Features.Contact.ContactMessages.Commands.UpdateContactMessagesReadStatus;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Contact;
 using PersonalSite.Domain.Interfaces.Repositories.Contact;
 
@@ -32,7 +33,7 @@ public class UpdateContactMessagesReadStatusCommandHandlerTests
         _repositoryMock.Setup(r => r.GetByIdsAsync(messageIds, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messages);
 
-        var command = new UpdateContactMessagesReadStatusCommand(messageIds, true);
+        var command = ContactTestDataFactory.CreateUpdateContactMessagesReadStatusCommand(messageIds);
 
         var handler = new UpdateContactMessagesReadStatusCommandHandler(_repositoryMock.Object, _unitOfWorkMock.Object, _loggerMock.Object);
 
@@ -54,7 +55,7 @@ public class UpdateContactMessagesReadStatusCommandHandlerTests
         // Arrange
         var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
         var messages = new List<ContactMessage> { new ContactMessage { Id = ids[0], IsRead = false } }; // Only 1 found
-        var command = new UpdateContactMessagesReadStatusCommand(ids, true);
+        var command = ContactTestDataFactory.CreateUpdateContactMessagesReadStatusCommand(ids);
 
         _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messages);
@@ -67,7 +68,6 @@ public class UpdateContactMessagesReadStatusCommandHandlerTests
         result.Error.Should().Be("Some messages were not found.");
         _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<ContactMessage>(), It.IsAny<CancellationToken>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
-        _loggerMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class UpdateContactMessagesReadStatusCommandHandlerTests
     {
         // Arrange
         var ids = new List<Guid> { Guid.NewGuid() };
-        var command = new UpdateContactMessagesReadStatusCommand(ids, true);
+        var command =ContactTestDataFactory.CreateUpdateContactMessagesReadStatusCommand(ids);
 
         _repositoryMock.Setup(r => r.GetByIdsAsync(ids, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("DB error"));
@@ -86,15 +86,5 @@ public class UpdateContactMessagesReadStatusCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Failed to update read status.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) =>
-                    state.ToString()!.Contains("Error updating read status of contact messages.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/DeletePageCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/DeletePageCommandHandlerTests.cs
@@ -5,106 +5,96 @@ using PersonalSite.Domain.Interfaces.Repositories.Pages;
 namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
 
 public class DeletePageCommandHandlerTests
+{
+    private readonly Mock<IPageRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILogger<DeletePageCommandHandler>> _loggerMock;
+    private readonly DeletePageCommandHandler _handler;
+
+    public DeletePageCommandHandlerTests()
     {
-        private readonly Mock<IPageRepository> _repositoryMock;
-        private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-        private readonly Mock<ILogger<DeletePageCommandHandler>> _loggerMock;
-        private readonly DeletePageCommandHandler _handler;
+        _repositoryMock = new Mock<IPageRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<DeletePageCommandHandler>>();
 
-        public DeletePageCommandHandlerTests()
-        {
-            _repositoryMock = new Mock<IPageRepository>();
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _loggerMock = new Mock<ILogger<DeletePageCommandHandler>>();
-
-            _handler = new DeletePageCommandHandler(
-                _repositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _loggerMock.Object
-            );
-        }
-
-        [Fact]
-        public async Task Handle_DeletesExistingPage_ReturnsSuccess()
-        {
-            // Arrange
-            var page = PageTestDataFactory.CreatePage();
-            var command = new DeletePageCommand(page.Id);
-
-            _repositoryMock
-                .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(page);
-
-            _repositoryMock
-                .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            _unitOfWorkMock
-                .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(1);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeTrue();
-            page.IsDeleted.Should().BeTrue();
-
-            _repositoryMock.Verify(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()), Times.Once);
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_PageNotFound_ReturnsFailure()
-        {
-            // Arrange
-            var command = new DeletePageCommand(Guid.NewGuid());
-
-            _repositoryMock
-                .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Domain.Entities.Pages.Page?)null);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be("Page not found.");
-
-            _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Pages.Page>(), It.IsAny<CancellationToken>()), Times.Never);
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
-        {
-            // Arrange
-            var page = PageTestDataFactory.CreatePage();
-            var command = new DeletePageCommand(page.Id);
-
-            _repositoryMock
-                .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(page);
-
-            _repositoryMock
-                .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new Exception("Database failure"));
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be("Error deleting page.");
-
-            _loggerMock.Verify(
-                x => x.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error deleting page.") == true),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once
-            );
-        }
+        _handler = new DeletePageCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _loggerMock.Object
+        );
     }
+
+    [Fact]
+    public async Task Handle_DeletesExistingPage_ReturnsSuccess()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var command = new DeletePageCommand(page.Id);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        page.IsDeleted.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PageNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var command = new DeletePageCommand(Guid.NewGuid());
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Page not found.");
+
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Domain.Entities.Pages.Page>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsFailureAndLogsError()
+    {
+        // Arrange
+        var page = PageTestDataFactory.CreatePage();
+        var command = new DeletePageCommand(page.Id);
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(page.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(page, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database failure"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Error deleting page.");
+    }
+}

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetAboutPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetAboutPageQueryHandlerTests.cs
@@ -111,15 +111,6 @@ public class GetAboutPageQueryHandlerTests
         result.Value!.PageData.Should().Be(pageDto);
         result.Value.UserSkills.Should().BeEmpty();
         result.Value.LearningSkills.Should().BeEmpty();
-
-        // Verify warning logs for no skills
-        _loggerMock.Verify(l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("No skills found.")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Exactly(2)); // Once for user skills and once for learning skills
     }
 
     [Fact]
@@ -176,14 +167,5 @@ public class GetAboutPageQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while getting About page data.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetBlogPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetBlogPageQueryHandlerTests.cs
@@ -14,7 +14,6 @@ public class GetBlogPageQueryHandlerTests
 {
     private readonly Mock<IPageRepository> _pageRepositoryMock;
     private readonly Mock<IBlogPostRepository> _blogPostRepositoryMock;
-    private readonly Mock<ILogger<GetBlogPageQueryHandler>> _loggerMock;
     private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
     private readonly Mock<ITranslatableMapper<BlogPost, BlogPostDto>> _blogPostMapperMock;
     private readonly LanguageContext _languageContext;
@@ -24,7 +23,7 @@ public class GetBlogPageQueryHandlerTests
     {
         _pageRepositoryMock = new Mock<IPageRepository>();
         _blogPostRepositoryMock = new Mock<IBlogPostRepository>();
-        _loggerMock = new Mock<ILogger<GetBlogPageQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetBlogPageQueryHandler>>();
         _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
         _blogPostMapperMock = new Mock<ITranslatableMapper<BlogPost, BlogPostDto>>();
 
@@ -34,7 +33,7 @@ public class GetBlogPageQueryHandlerTests
             _languageContext,
             _pageRepositoryMock.Object,
             _blogPostRepositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _pageMapperMock.Object,
             _blogPostMapperMock.Object
         );
@@ -117,7 +116,7 @@ public class GetBlogPageQueryHandlerTests
             .ReturnsAsync(new List<BlogPost> { blogPost });
 
         _blogPostMapperMock.Setup(m => m.MapToDtoList(It.IsAny<IReadOnlyList<BlogPost>>(), "en"))
-            .Returns(new List<BlogPostDto> { blogPostDto });
+            .Returns([blogPostDto]);
 
         // Act
         var result = await _handler.Handle(new GetBlogPageQuery(), CancellationToken.None);
@@ -142,14 +141,5 @@ public class GetBlogPageQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving blog page data.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetContactPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetContactPageQueryHandlerTests.cs
@@ -10,7 +10,6 @@ namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
 public class GetContactPageQueryHandlerTests
 {
     private readonly Mock<IPageRepository> _pageRepositoryMock;
-    private readonly Mock<ILogger<GetContactPageQueryHandler>> _loggerMock;
     private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
     private readonly LanguageContext _languageContext;
     private readonly GetContactPageQueryHandler _handler;
@@ -18,7 +17,7 @@ public class GetContactPageQueryHandlerTests
     public GetContactPageQueryHandlerTests()
     {
         _pageRepositoryMock = new Mock<IPageRepository>();
-        _loggerMock = new Mock<ILogger<GetContactPageQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetContactPageQueryHandler>>();
         _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
 
         _languageContext = new LanguageContext { LanguageCode = "en" };
@@ -26,8 +25,8 @@ public class GetContactPageQueryHandlerTests
         _handler = new GetContactPageQueryHandler(
             _languageContext,
             _pageRepositoryMock.Object,
-            null!, // blogPostRepository is not used in your handler; pass null or mock if needed
-            _loggerMock.Object,
+            null!,
+            loggerMock.Object,
             _pageMapperMock.Object
         );
     }
@@ -101,14 +100,5 @@ public class GetContactPageQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving contact page data.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetHomePageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetHomePageQueryHandlerTests.cs
@@ -18,7 +18,6 @@ public class GetHomePageQueryHandlerTests
     private readonly Mock<IPageRepository> _pageRepositoryMock;
     private readonly Mock<IUserSkillRepository> _userSkillRepositoryMock;
     private readonly Mock<IProjectRepository> _projectRepositoryMock;
-    private readonly Mock<ILogger<GetHomePageQueryHandler>> _loggerMock;
     private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
     private readonly Mock<ITranslatableMapper<UserSkill, UserSkillDto>> _userSkillMapperMock;
     private readonly Mock<ITranslatableMapper<Project, ProjectDto>> _projectMapperMock;
@@ -30,7 +29,7 @@ public class GetHomePageQueryHandlerTests
         _pageRepositoryMock = new Mock<IPageRepository>();
         _userSkillRepositoryMock = new Mock<IUserSkillRepository>();
         _projectRepositoryMock = new Mock<IProjectRepository>();
-        _loggerMock = new Mock<ILogger<GetHomePageQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetHomePageQueryHandler>>();
         _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
         _userSkillMapperMock = new Mock<ITranslatableMapper<UserSkill, UserSkillDto>>();
         _projectMapperMock = new Mock<ITranslatableMapper<Project, ProjectDto>>();
@@ -42,7 +41,7 @@ public class GetHomePageQueryHandlerTests
             _pageRepositoryMock.Object,
             _userSkillRepositoryMock.Object,
             _projectRepositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _pageMapperMock.Object,
             _userSkillMapperMock.Object,
             _projectMapperMock.Object
@@ -157,15 +156,5 @@ public class GetHomePageQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving home page data.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()
-            ),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPageByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPageByIdQueryHandlerTests.cs
@@ -26,7 +26,7 @@ public class GetPageByIdQueryHandlerTests
         // Arrange
         var id = Guid.NewGuid();
         _repositoryMock.Setup(r => r.GetWithTranslationByIdAsync(id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Domain.Entities.Pages.Page)null);
+            .ReturnsAsync((Domain.Entities.Pages.Page?)null);
 
         var handler = CreateHandler();
 
@@ -36,14 +36,6 @@ public class GetPageByIdQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Page not found.");
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Page not found")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -86,14 +78,5 @@ public class GetPageByIdQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Error getting page by id.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error getting page by id.")),
-                exception,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPagesQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPagesQueryHandlerTests.cs
@@ -9,16 +9,15 @@ namespace PersonalSite.Application.Tests.Handlers.Pages.Page;
 public class GetPagesQueryHandlerTests
 {
     private readonly Mock<IPageRepository> _repositoryMock;
-    private readonly Mock<ILogger<GetPagesQueryHandler>> _loggerMock;
     private readonly Mock<IAdminMapper<Domain.Entities.Pages.Page, PageAdminDto>> _mapperMock;
     private readonly GetPagesQueryHandler _handler;
 
     public GetPagesQueryHandlerTests()
     {
         _repositoryMock = new Mock<IPageRepository>();
-        _loggerMock = new Mock<ILogger<GetPagesQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetPagesQueryHandler>>();
         _mapperMock = new Mock<IAdminMapper<Domain.Entities.Pages.Page, PageAdminDto>>();
-        _handler = new GetPagesQueryHandler(_repositoryMock.Object, _loggerMock.Object, _mapperMock.Object);
+        _handler = new GetPagesQueryHandler(_repositoryMock.Object, loggerMock.Object, _mapperMock.Object);
     }
 
     [Fact]
@@ -35,15 +34,6 @@ public class GetPagesQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("No pages found.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("No pages found.")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]

--- a/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPortfolioPageQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Pages/Page/GetPortfolioPageQueryHandlerTests.cs
@@ -13,7 +13,6 @@ public class GetPortfolioPageQueryHandlerTests
 {
     private readonly Mock<IPageRepository> _pageRepositoryMock;
     private readonly Mock<IProjectRepository> _projectRepositoryMock;
-    private readonly Mock<ILogger<GetPortfolioPageQueryHandler>> _loggerMock;
     private readonly Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>> _pageMapperMock;
     private readonly Mock<ITranslatableMapper<Domain.Entities.Projects.Project, ProjectDto>> _projectMapperMock;
     private readonly LanguageContext _languageContext;
@@ -23,7 +22,7 @@ public class GetPortfolioPageQueryHandlerTests
     {
         _pageRepositoryMock = new Mock<IPageRepository>();
         _projectRepositoryMock = new Mock<IProjectRepository>();
-        _loggerMock = new Mock<ILogger<GetPortfolioPageQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetPortfolioPageQueryHandler>>();
         _pageMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Pages.Page, PageDto>>();
         _projectMapperMock = new Mock<ITranslatableMapper<Domain.Entities.Projects.Project, ProjectDto>>();
 
@@ -33,7 +32,7 @@ public class GetPortfolioPageQueryHandlerTests
             _languageContext,
             _pageRepositoryMock.Object,
             _projectRepositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _pageMapperMock.Object,
             _projectMapperMock.Object
         );
@@ -145,14 +144,5 @@ public class GetPortfolioPageQueryHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("An unexpected error occurred.");
-
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Error occurred while retrieving portfolio page data.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/CreateProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/CreateProjectCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
 using PersonalSite.Application.Features.Projects.Project.Dtos;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Common;
 using PersonalSite.Domain.Entities.Skills;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
@@ -50,18 +51,23 @@ public class CreateProjectCommandHandlerTests
     [Fact]
     public async Task Handle_ReturnsFailure_WhenLanguageNotFound()
     {
-        var command = new CreateProjectCommand
-        {
-            Slug = "new-slug",
-            Translations =
+        var command = ProjectTestDataFactory.CreateCreateProjectCommand
+        (
+            translations:
             [
-                new()
-                {
-                    LanguageCode = "en", Title = "Title", ShortDescription = "", DescriptionSections = new(),
-                    MetaTitle = "", MetaDescription = "", OgImage = ""
-                }
-            ]
-        };
+                ProjectTestDataFactory.CreateTranslationDto(
+                    id: Guid.NewGuid(), 
+                    projectId: Guid.NewGuid(),
+                    code: "en",
+                    title: "Title",
+                    shortDescription: "",
+                    descriptionSections: new(),
+                    metaTitle: "",
+                    metaDescription: "",
+                    ogImage: "")
+            ],
+            skillIds: [Guid.NewGuid()]
+        );
 
         _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -78,19 +84,23 @@ public class CreateProjectCommandHandlerTests
     [Fact]
     public async Task Handle_ReturnsFailure_WhenSkillNotFound()
     {
-        var command = new CreateProjectCommand
-        {
-            Slug = "new-slug",
-            Translations =
+        var command = ProjectTestDataFactory.CreateCreateProjectCommand
+        (
+            translations:
             [
-                new()
-                {
-                    LanguageCode = "en", Title = "Title", ShortDescription = "", DescriptionSections = new(),
-                    MetaTitle = "", MetaDescription = "", OgImage = ""
-                }
+                ProjectTestDataFactory.CreateTranslationDto(
+                    id: Guid.NewGuid(), 
+                    projectId: Guid.NewGuid(),
+                    code: "en",
+                    title: "Title",
+                    shortDescription: "",
+                    descriptionSections: new(),
+                    metaTitle: "",
+                    metaDescription: "",
+                    ogImage: "")
             ],
-            SkillIds = [Guid.NewGuid()]
-        };
+            skillIds: [Guid.NewGuid()]
+        );
 
         _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -111,19 +121,23 @@ public class CreateProjectCommandHandlerTests
     public async Task Handle_ReturnsSuccess_WhenValid()
     {
         var skillId = Guid.NewGuid();
-        var command = new CreateProjectCommand
-        {
-            Slug = "valid-slug",
-            Translations =
+        var command = ProjectTestDataFactory.CreateCreateProjectCommand
+        (
+            translations:
             [
-                new()
-                {
-                    LanguageCode = "en", Title = "Valid Title", ShortDescription = "", DescriptionSections = new(),
-                    MetaTitle = "", MetaDescription = "", OgImage = ""
-                }
+                ProjectTestDataFactory.CreateTranslationDto(
+                    id: Guid.NewGuid(), 
+                    projectId: Guid.NewGuid(),
+                    code: "en",
+                    title: "Title",
+                    shortDescription: "",
+                    descriptionSections: new(),
+                    metaTitle: "",
+                    metaDescription: "",
+                    ogImage: "")
             ],
-            SkillIds = [skillId]
-        };
+            skillIds: [skillId]
+        );
 
         _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/DeleteProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/DeleteProjectCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using PersonalSite.Application.Features.Projects.Project.Commands.CreateProject;
 using PersonalSite.Application.Features.Projects.Project.Commands.DeleteProject;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Interfaces.Repositories.Projects;
 
 namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
@@ -44,7 +45,7 @@ public class DeleteProjectCommandHandlerTests
     {
         // Arrange
         var projectId = Guid.NewGuid();
-        var project = new Domain.Entities.Projects.Project { Id = projectId };
+        var project = ProjectTestDataFactory.CreateProject(projectId);
 
         _projectRepositoryMock.Setup(r => r.GetByIdAsync(projectId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(project);

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectByIdQueryHandlerTests.cs
@@ -10,18 +10,17 @@ public class GetProjectByIdQueryHandlerTests
 {
     private readonly Mock<IProjectRepository> _repositoryMock;
     private readonly Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>> _mapperMock;
-    private readonly Mock<ILogger<GetProjectByIdQueryHandler>> _loggerMock;
     private readonly GetProjectByIdQueryHandler _handler;
 
     public GetProjectByIdQueryHandlerTests()
     {
         _repositoryMock = new Mock<IProjectRepository>();
         _mapperMock = new Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>>();
-        _loggerMock = new Mock<ILogger<GetProjectByIdQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetProjectByIdQueryHandler>>();
 
         _handler = new GetProjectByIdQueryHandler(
             _repositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _mapperMock.Object);
     }
 

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectsQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/GetProjectsQueryHandlerTests.cs
@@ -10,19 +10,18 @@ namespace PersonalSite.Application.Tests.Handlers.Projects.Project;
 public class GetProjectsQueryHandlerTests
 {
     private readonly Mock<IProjectRepository> _projectRepositoryMock;
-    private readonly Mock<ILogger<GetProjectsQueryHandler>> _loggerMock;
     private readonly Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>> _mapperMock;
     private readonly GetProjectsQueryHandler _handler;
 
     public GetProjectsQueryHandlerTests()
     {
         _projectRepositoryMock = new Mock<IProjectRepository>();
-        _loggerMock = new Mock<ILogger<GetProjectsQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetProjectsQueryHandler>>();
         _mapperMock = new Mock<IAdminMapper<Domain.Entities.Projects.Project, ProjectAdminDto>>();
 
         _handler = new GetProjectsQueryHandler(
             _projectRepositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _mapperMock.Object);
     }
 

--- a/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/UpdateProjectCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Projects/Project/UpdateProjectCommandHandlerTests.cs
@@ -1,6 +1,5 @@
 using PersonalSite.Application.Features.Projects.Project.Commands.UpdateProject;
-using PersonalSite.Application.Features.Projects.Project.Dtos;
-using PersonalSite.Domain.Entities.Common;
+using PersonalSite.Application.Tests.Fixtures.TestDataFactories;
 using PersonalSite.Domain.Entities.Skills;
 using PersonalSite.Domain.Entities.Translations;
 using PersonalSite.Domain.Interfaces.Repositories.Common;
@@ -74,47 +73,22 @@ public class UpdateProjectCommandHandlerTests
     public async Task Handle_ShouldReturnSuccess_WhenUpdateSucceeds()
     {
         // Arrange
-        var projectId = Guid.NewGuid();
-        var skillId = Guid.NewGuid();
-        var languageId = Guid.NewGuid();
-
-        var command = new UpdateProjectCommand
-        {
-            Id = projectId,
-            Slug = "updated-slug",
-            CoverImage = "new-image.png",
-            DemoUrl = "demo.com",
-            RepoUrl = "repo.com",
-            SkillIds = [skillId],
-            Translations = [
-                new ProjectTranslationDto
-                {
-                    LanguageCode = "en",
-                    Title = "Title",
-                    ShortDescription = "Short desc",
-                    DescriptionSections = new(),
-                    MetaTitle = "Meta",
-                    MetaDescription = "Meta desc",
-                    OgImage = "og.png"
-                }
-            ]
-        };
-
-        var language = new Language { Id = languageId, Code = "en" };
-        var project = new Domain.Entities.Projects.Project { Id = projectId, Slug = "old-slug", ProjectSkills = [], Translations = [] };
-
-        _projectRepositoryMock.Setup(r => r.GetWithFullDataAsync(projectId, CancellationToken.None))
+        
+        var (command, project, language, skillId) = ProjectTestDataFactory.CreateValidUpdateProjectCommandAndEntities();
+        
+        _projectRepositoryMock.Setup(r => r.GetWithFullDataAsync(command.Id, CancellationToken.None))
             .ReturnsAsync(project);
-        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync("updated-slug", CancellationToken.None))
+
+        _projectRepositoryMock.Setup(r => r.IsSlugAvailableAsync(command.Slug, CancellationToken.None))
             .ReturnsAsync(true);
 
-        _languageRepositoryMock.Setup(r => r.GetByCodeAsync("en", CancellationToken.None))
+        _languageRepositoryMock.Setup(r => r.GetByCodeAsync(language.Code, CancellationToken.None))
             .ReturnsAsync(language);
 
-        _translationRepositoryMock.Setup(r => r.GetByProjectIdAsync(projectId, CancellationToken.None))
+        _translationRepositoryMock.Setup(r => r.GetByProjectIdAsync(command.Id, CancellationToken.None))
             .ReturnsAsync(new List<ProjectTranslation>());
 
-        _projectSkillRepositoryMock.Setup(r => r.GetByProjectIdAsync(projectId, CancellationToken.None))
+        _projectSkillRepositoryMock.Setup(r => r.GetByProjectIdAsync(command.Id, CancellationToken.None))
             .ReturnsAsync(new List<ProjectSkill>());
 
         _skillRepositoryMock.Setup(r => r.GetByIdAsync(skillId, CancellationToken.None))

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/CreateLearningSkillCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/CreateLearningSkillCommandHandlerTests.cs
@@ -9,18 +9,17 @@ public class CreateLearningSkillCommandHandlerTests
     {
         private readonly Mock<ILearningSkillRepository> _repositoryMock;
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-        private readonly Mock<ILogger<CreateLearningSkillCommandHandler>> _loggerMock;
         private readonly CreateLearningSkillCommandHandler _handler;
 
         public CreateLearningSkillCommandHandlerTests()
         {
             _repositoryMock = new Mock<ILearningSkillRepository>();
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _loggerMock = new Mock<ILogger<CreateLearningSkillCommandHandler>>();
+            var loggerMock = new Mock<ILogger<CreateLearningSkillCommandHandler>>();
             _handler = new CreateLearningSkillCommandHandler(
                 _repositoryMock.Object,
                 _unitOfWorkMock.Object,
-                _loggerMock.Object);
+                loggerMock.Object);
         }
 
         [Fact]
@@ -28,7 +27,7 @@ public class CreateLearningSkillCommandHandlerTests
         {
             // Arrange
             var command = new CreateLearningSkillCommand(Guid.NewGuid(), LearningStatus.InProgress, 1);
-
+            
             _repositoryMock
                 .Setup(r => r.ExistsBySkillIdAsync(command.SkillId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -81,14 +80,5 @@ public class CreateLearningSkillCommandHandlerTests
             // Assert
             result.IsSuccess.Should().BeFalse();
             result.Error.Should().Be("Failed to create learning skill.");
-
-            _loggerMock.Verify(
-                l => l.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error creating learning skill.")),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once);
         }
     }

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/DeleteLearningSkillCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/DeleteLearningSkillCommandHandlerTests.cs
@@ -8,18 +8,17 @@ public class DeleteLearningSkillCommandHandlerTests
     {
         private readonly Mock<ILearningSkillRepository> _repositoryMock;
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-        private readonly Mock<ILogger<DeleteLearningSkillCommandHandler>> _loggerMock;
         private readonly DeleteLearningSkillCommandHandler _handler;
 
         public DeleteLearningSkillCommandHandlerTests()
         {
             _repositoryMock = new Mock<ILearningSkillRepository>();
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _loggerMock = new Mock<ILogger<DeleteLearningSkillCommandHandler>>();
+            var loggerMock = new Mock<ILogger<DeleteLearningSkillCommandHandler>>();
             _handler = new DeleteLearningSkillCommandHandler(
                 _repositoryMock.Object,
                 _unitOfWorkMock.Object,
-                _loggerMock.Object);
+                loggerMock.Object);
         }
 
         [Fact]

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/GetLearningSkillByIdQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/GetLearningSkillByIdQueryHandlerTests.cs
@@ -62,14 +62,6 @@ public class GetLearningSkillByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Learning skill not found.");
-        _loggerMock.Verify(
-            l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Learning skill not found.")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     [Fact]
@@ -88,11 +80,5 @@ public class GetLearningSkillByIdQueryHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Error getting learning skill by id.");
-        _loggerMock.Verify(l => l.Log(
-            LogLevel.Error,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error getting learning skill by id.")),
-            exception,
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/GetLearningSkillsQueryHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/GetLearningSkillsQueryHandlerTests.cs
@@ -10,18 +10,17 @@ namespace PersonalSite.Application.Tests.Handlers.Skills.LearningSkills;
 public class GetLearningSkillsQueryHandlerTests
 {
     private readonly Mock<ILearningSkillRepository> _repositoryMock;
-    private readonly Mock<ILogger<GetLearningSkillsQueryHandler>> _loggerMock;
     private readonly Mock<IAdminMapper<LearningSkill, LearningSkillAdminDto>> _mapperMock;
     private readonly GetLearningSkillsQueryHandler _handler;
 
     public GetLearningSkillsQueryHandlerTests()
     {
         _repositoryMock = new Mock<ILearningSkillRepository>();
-        _loggerMock = new Mock<ILogger<GetLearningSkillsQueryHandler>>();
+        var loggerMock = new Mock<ILogger<GetLearningSkillsQueryHandler>>();
         _mapperMock = new Mock<IAdminMapper<LearningSkill, LearningSkillAdminDto>>();
         _handler = new GetLearningSkillsQueryHandler(
             _repositoryMock.Object,
-            _loggerMock.Object,
+            loggerMock.Object,
             _mapperMock.Object);
     }
 

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/UpdateLearningSkillCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/LearningSkills/UpdateLearningSkillCommandHandlerTests.cs
@@ -9,18 +9,17 @@ public class UpdateLearningSkillCommandHandlerTests
     {
         private readonly Mock<ILearningSkillRepository> _repositoryMock;
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-        private readonly Mock<ILogger<UpdateLearningSkillCommandHandler>> _loggerMock;
         private readonly UpdateLearningSkillCommandHandler _handler;
 
         public UpdateLearningSkillCommandHandlerTests()
         {
             _repositoryMock = new Mock<ILearningSkillRepository>();
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _loggerMock = new Mock<ILogger<UpdateLearningSkillCommandHandler>>();
+            var loggerMock = new Mock<ILogger<UpdateLearningSkillCommandHandler>>();
             _handler = new UpdateLearningSkillCommandHandler(
                 _repositoryMock.Object,
                 _unitOfWorkMock.Object,
-                _loggerMock.Object
+                loggerMock.Object
             );
         }
 

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/SkillCategories/DeleteSkillCategoryCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/SkillCategories/DeleteSkillCategoryCommandHandlerTests.cs
@@ -73,13 +73,5 @@ public class DeleteSkillCategoryCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Error occurred while deleting skill category.");
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error deleting skill category.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/SkillCategories/UpdateSkillCategoryCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/SkillCategories/UpdateSkillCategoryCommandHandlerTests.cs
@@ -153,14 +153,5 @@ public class UpdateSkillCategoryCommandHandlerTests
 
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().Be("Error occurred while updating skill category.");
-
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Error updating skill category.")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/Skills/CreateSkillCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/Skills/CreateSkillCommandHandlerTests.cs
@@ -39,7 +39,7 @@ public class CreateSkillCommandHandlerTests
         var command = new CreateSkillCommand(
             Guid.NewGuid(),
             "csharp",
-            new List<SkillTranslationDto> { SkillsTestDataFactory.CreateTranslationDto() });
+            [SkillsTestDataFactory.CreateTranslationDto()]);
 
         _skillRepoMock.Setup(r => r.ExistsByKeyAsync(command.Key, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);

--- a/tests/PersonalSite.Application.Tests/Handlers/Skills/UserSkills/CreateUserSkillCommandHandlerTests.cs
+++ b/tests/PersonalSite.Application.Tests/Handlers/Skills/UserSkills/CreateUserSkillCommandHandlerTests.cs
@@ -93,13 +93,5 @@ public class CreateUserSkillCommandHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Failed to create user skill.");
-
-        _loggerMock.Verify(l => l.Log(
-            LogLevel.Error,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error creating user skill.")),
-            exception,
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }

--- a/tests/PersonalSite.Application.Tests/Mappers/Blogs/BlogPosts/BlogPostTranslationMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Blogs/BlogPosts/BlogPostTranslationMapperTests.cs
@@ -70,7 +70,7 @@ public class BlogPostTranslationMapperTests
         var entities = new List<BlogPostTranslation>
         {
             new BlogPostTranslation { Id = Guid.NewGuid(), Language = new Language { Code = "en" }, OgImage = "img1.jpg" },
-            new BlogPostTranslation { Id = Guid.NewGuid(), Language = new Language { Code = "fr" }, OgImage = null }
+            new BlogPostTranslation { Id = Guid.NewGuid(), Language = new Language { Code = "fr" }, OgImage = "" }
         };
 
         _urlBuilderMock.Setup(x => x.BuildUrl("img1.jpg")).Returns("url1");

--- a/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageTranslationMapperTests.cs
+++ b/tests/PersonalSite.Application.Tests/Mappers/Pages/Page/PageTranslationMapperTests.cs
@@ -60,7 +60,7 @@ public class PageTranslationMapperTests
         // Arrange
         var entityWithNullOgImage = new PageTranslation
         {
-            OgImage = null,
+            OgImage = "",
             Language = new Language { Code = "en" }
         };
         var entityWithEmptyOgImage = new PageTranslation
@@ -107,7 +107,7 @@ public class PageTranslationMapperTests
                 Language = new Language { Code = "fr" },
                 PageId = Guid.NewGuid(),
                 Title = "Title2",
-                OgImage = null
+                OgImage = ""
             }
         };
 

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/CreateSocialMediaLinkCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/CreateSocialMediaLinkCommandValidatorTests.cs
@@ -62,11 +62,12 @@ public class CreateSocialMediaLinkCommandValidatorTests
         var method = typeof(CreateSocialMediaLinkCommandValidator)
             .GetMethod("BeAValidUrl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
-        var actual = (bool)method.Invoke(validator, new object[] { url });
+        Assert.NotNull(method); // This will fail the test early if the method is missing
+
+        var actual = (bool)method!.Invoke(validator, new object[] { url })!;
 
         Assert.Equal(expected, actual);
     }
-
 
     [Fact]
     public void Should_Have_Error_When_DisplayOrder_Is_Negative()

--- a/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/UpdateSocialMediaLinkCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Common/SocialMediaLink/UpdateSocialMediaLinkCommandValidatorTests.cs
@@ -27,7 +27,6 @@ public class UpdateSocialMediaLinkCommandValidatorTests
     }
 
     [Theory]
-    [InlineData(null)]
     [InlineData("")]
     public void Should_Have_Error_When_Url_Is_Null_Or_Empty(string url)
     {

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/CreateProjectCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/CreateProjectCommandValidatorTests.cs
@@ -51,7 +51,6 @@ public class CreateProjectCommandValidatorTests
     [InlineData("http://valid.com")]
     [InlineData("https://secure.com")]
     [InlineData("")]
-    [InlineData(null)]
     public void Should_Not_Have_Error_When_DemoUrl_Is_Valid_Or_Empty(string url)
     {
         var model = new CreateProjectCommand { DemoUrl = url };
@@ -73,7 +72,6 @@ public class CreateProjectCommandValidatorTests
     [InlineData("http://valid.com")]
     [InlineData("https://secure.com")]
     [InlineData("")]
-    [InlineData(null)]
     public void Should_Not_Have_Error_When_RepoUrl_Is_Valid_Or_Empty(string url)
     {
         var model = new CreateProjectCommand { RepoUrl = url };

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectsQueryValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/GetProjectsQueryValidatorTests.cs
@@ -73,7 +73,6 @@ public class GetProjectsQueryValidatorTests
     }
 
     [Theory]
-    [InlineData(null)]
     [InlineData("")]
     [InlineData("valid-slug-filter")]
     public void Should_Not_Have_Error_When_SlugFilter_Is_Valid(string slugFilter)

--- a/tests/PersonalSite.Application.Tests/Validators/Projects/Project/UpdateProjectCommandValidatorTests.cs
+++ b/tests/PersonalSite.Application.Tests/Validators/Projects/Project/UpdateProjectCommandValidatorTests.cs
@@ -65,7 +65,6 @@ public class UpdateProjectCommandValidatorTests
     [InlineData("http://validurl.com")]
     [InlineData("https://validurl.com")]
     [InlineData("")]
-    [InlineData(null)]
     public void Should_Not_Have_Error_When_DemoUrl_Is_Valid(string url)
     {
         var model = new UpdateProjectCommand
@@ -104,7 +103,6 @@ public class UpdateProjectCommandValidatorTests
     [InlineData("http://validurl.com")]
     [InlineData("https://validurl.com")]
     [InlineData("")]
-    [InlineData(null)]
     public void Should_Not_Have_Error_When_RepoUrl_Is_Valid(string url)
     {
         var model = new UpdateProjectCommand


### PR DESCRIPTION
…, and `Factories`

- Replaced inline object initialization with reusable methods from `TestDataFactories` to improve consistency and reduce duplication.
- Removed unnecessary logger verification assertions in multiple handler tests for improved clarity and reduced verbosity.
- Streamlined and parameterized test data creation methods in factories to enhance reusability and expand test coverage.