### PR TITLE
Introduce modular S3 reference providers and refactor orphan file cle…

### DIFF
--- a/src/PersonalSite.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/PersonalSite.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace PersonalSite.Infrastructure.DependencyInjection;
+﻿using PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+namespace PersonalSite.Infrastructure.DependencyInjection;
 
 public static class InfrastructureServiceCollectionExtensions
 {
@@ -10,6 +12,13 @@ public static class InfrastructureServiceCollectionExtensions
         
         services.AddSingleton<IBackgroundQueue, BackgroundQueue>();
         services.AddHostedService<QueuedHostedService>();
+        
+        services.Scan(scan => scan
+            .FromAssemblyOf<IS3ReferenceProvider>()
+            .AddClasses(classes => classes.AssignableTo<IS3ReferenceProvider>())
+            .AsImplementedInterfaces()
+            .WithScopedLifetime());
+
         
         services.AddHostedService<S3OrphanFileCleanupJob>();
         

--- a/src/PersonalSite.Infrastructure/PersonalSite.Infrastructure.csproj
+++ b/src/PersonalSite.Infrastructure/PersonalSite.Infrastructure.csproj
@@ -16,6 +16,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+      <PackageReference Include="Scrutor" Version="6.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/AsyncEnumerableExtensions.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/AsyncEnumerableExtensions.cs
@@ -1,0 +1,12 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public static class AsyncEnumerableExtensions
+{
+    public static async Task<List<T>> SelectManyAsync<T>(
+        this IEnumerable<IS3ReferenceProvider> providers,
+        Func<IS3ReferenceProvider, Task<IEnumerable<T>>> selector)
+    {
+        var results = await Task.WhenAll(providers.Select(selector));
+        return results.SelectMany(r => r).ToList();
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/BlogPostS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/BlogPostS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class BlogPostS3ReferenceProvider : IS3ReferenceProvider
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public BlogPostS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.BlogPosts
+            .Where(bp => !string.IsNullOrEmpty(bp.CoverImage))
+            .Select(bp => bp.CoverImage)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/BlogPostTranslationS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/BlogPostTranslationS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class BlogPostTranslationS3ReferenceProvider : IS3ReferenceProvider 
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public BlogPostTranslationS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.BlogPostTranslations
+            .Where(bp => !string.IsNullOrEmpty(bp.OgImage))
+            .Select(bp => bp.OgImage)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/IS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/IS3ReferenceProvider.cs
@@ -1,0 +1,6 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public interface IS3ReferenceProvider
+{
+    Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken);
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/PageTranslationS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/PageTranslationS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class PageTranslationS3ReferenceProvider : IS3ReferenceProvider 
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public PageTranslationS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.PageTranslations
+            .Where(bp => !string.IsNullOrEmpty(bp.OgImage))
+            .Select(bp => bp.OgImage)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ProjectS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ProjectS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class ProjectS3ReferenceProvider : IS3ReferenceProvider
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public ProjectS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Projects
+            .Where(bp => !string.IsNullOrEmpty(bp.CoverImage))
+            .Select(bp => bp.CoverImage)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ProjectTranslationS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ProjectTranslationS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class ProjectTranslationS3ReferenceProvider : IS3ReferenceProvider 
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public ProjectTranslationS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.ProjectTranslations
+            .Where(bp => !string.IsNullOrEmpty(bp.OgImage))
+            .Select(bp => bp.OgImage)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ResumeS3ReferenceProvider.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3ReferenceProviders/ResumeS3ReferenceProvider.cs
@@ -1,0 +1,19 @@
+namespace PersonalSite.Infrastructure.Storage.S3ReferenceProviders;
+
+public class ResumeS3ReferenceProvider : IS3ReferenceProvider
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public ResumeS3ReferenceProvider(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IEnumerable<string>> GetUsedS3UrlsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Resumes
+            .Where(r => !string.IsNullOrEmpty(r.FileUrl))
+            .Select(r => r.FileUrl)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/PersonalSite.Infrastructure/Storage/S3StorageService.cs
+++ b/src/PersonalSite.Infrastructure/Storage/S3StorageService.cs
@@ -35,7 +35,7 @@ public class S3StorageService : IStorageService
 
             await fileTransferUtility.UploadAsync(uploadRequest, cancellationToken);
 
-            return $"https://{_settings.BucketName}.s3.{_settings.Region}.amazonaws.com/{key}";
+            return key;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
…anup logic

- Added `IS3ReferenceProvider` interface and multiple implementations (`BlogPostS3ReferenceProvider`, `ProjectS3ReferenceProvider`, etc.) for retrieving used S3 URLs by entity type.
- Refactored `S3OrphanFileCleanupJob` to utilize `IS3ReferenceProvider` for determining referenced S3 keys, improving extensibility.
- Updated bucket URL generation logic in `S3StorageService` to return only the file key.
- Registered `IS3ReferenceProvider` implementations using Scrutor for dependency injection.