### PR TITLE
Replace `AcceptLanguageInterceptor` with `LocaleInterceptor`, enhance…

### DIFF
--- a/frontend/public-site/src/app/app.config.ts
+++ b/frontend/public-site/src/app/app.config.ts
@@ -10,17 +10,24 @@ import {provideTranslocoPersistLang, cookiesStorage} from '@ngneat/transloco-per
 import { StaticLoader } from './core/i18n/transloco.loader';
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import {HTTP_INTERCEPTORS, provideHttpClient, withFetch} from '@angular/common/http';
-import {AcceptLanguageInterceptor} from './core/interceptors/accept-language.interceptor';
+import {HTTP_INTERCEPTORS, provideHttpClient, withFetch, withInterceptorsFromDi} from '@angular/common/http';
 import {firstValueFrom, of} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {LanguageService} from './core/services/language.service';
 import {isPlatformBrowser} from '@angular/common';
-
+import {LocaleInterceptor} from './interceptors/locale.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideHttpClient(withFetch()),
+    provideHttpClient(
+      withFetch(),
+      withInterceptorsFromDi()
+    ),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: LocaleInterceptor,
+      multi: true
+    },
 
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
@@ -79,11 +86,6 @@ export const appConfig: ApplicationConfig = {
       storage: {
         useValue: cookiesStorage()
       }
-    }),
-    {
-      provide: HTTP_INTERCEPTORS,
-      useClass: AcceptLanguageInterceptor,
-      multi: true
-    }
+    })
   ]
 };

--- a/frontend/public-site/src/app/core/layout/Header/language-switcher.component/language-switcher.component.ts
+++ b/frontend/public-site/src/app/core/layout/Header/language-switcher.component/language-switcher.component.ts
@@ -11,7 +11,7 @@ import { TranslocoService} from '@ngneat/transloco';
 import { AVAILABLE_LANGS, Language } from '../../../i18n/languages.enum';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import {map} from 'rxjs';
 import {CustomBreakpoints} from '../../../../shared/utils/custom-breakpoints';
 
 @Component({
@@ -61,7 +61,6 @@ export class LanguageSwitcherComponent implements AfterViewInit {
     this.trans.setActiveLang(lang);
     this.current.set(lang);
     this.open.set(false);
-    location.reload()
   }
 
   currentLangName(): string {

--- a/frontend/public-site/src/app/features/cookies/cookies.component/cookies.component.ts
+++ b/frontend/public-site/src/app/features/cookies/cookies.component/cookies.component.ts
@@ -1,6 +1,8 @@
 import {Component, inject, OnInit} from '@angular/core';
 import {PageDto} from '../../../shared/models/page-dtos';
 import {PagesApiService} from '../../../core/services/pages-api.service';
+import {TranslocoService} from '@ngneat/transloco';
+import {Subscription} from 'rxjs';
 
 @Component({
   selector: 'app-cookies',
@@ -11,8 +13,26 @@ import {PagesApiService} from '../../../core/services/pages-api.service';
 export class CookiesComponent implements OnInit {
   page: PageDto | null = null;
   private pagesApi = inject(PagesApiService);
+  private translocoService = inject(TranslocoService);
+  private langChangedSubscription!: Subscription;
 
   ngOnInit(): void {
+    this.loadData();
+
+    this.langChangedSubscription = this.translocoService.events$.subscribe(event => {
+      if (event.type === 'langChanged') {
+        this.loadData();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.langChangedSubscription) {
+      this.langChangedSubscription.unsubscribe();
+    }
+  }
+
+  private loadData(): void {
     this.pagesApi.getCookiesPage().subscribe({
       next: (response) => {
         this.page = response.pageData;

--- a/frontend/public-site/src/app/features/privacy/privacy.component/privacy.component.ts
+++ b/frontend/public-site/src/app/features/privacy/privacy.component/privacy.component.ts
@@ -1,6 +1,8 @@
 import {Component, inject, OnInit} from '@angular/core';
 import {PageDto} from '../../../shared/models/page-dtos';
 import {PagesApiService} from '../../../core/services/pages-api.service';
+import {TranslocoService} from '@ngneat/transloco';
+import {Subscription} from 'rxjs';
 
 @Component({
   selector: 'app-privacy',
@@ -12,8 +14,26 @@ import {PagesApiService} from '../../../core/services/pages-api.service';
 export class PrivacyComponent implements OnInit {
   page: PageDto | null = null;
   private pagesApi = inject(PagesApiService);
+  private translocoService = inject(TranslocoService);
+  private langChangedSubscription!: Subscription;
 
   ngOnInit(): void {
+    this.loadData();
+
+    this.langChangedSubscription = this.translocoService.events$.subscribe(event => {
+      if (event.type === 'langChanged') {
+        this.loadData();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.langChangedSubscription) {
+      this.langChangedSubscription.unsubscribe();
+    }
+  }
+
+  private loadData(): void {
     this.pagesApi.getPrivacyPage().subscribe({
       next: (response) => {
         this.page = response.pageData;

--- a/frontend/public-site/src/app/interceptors/locale.interceptor.ts
+++ b/frontend/public-site/src/app/interceptors/locale.interceptor.ts
@@ -7,12 +7,17 @@ import { Observable } from 'rxjs';
 import { TranslocoService } from '@ngneat/transloco';
 
 @Injectable()
-export class AcceptLanguageInterceptor implements HttpInterceptor {
+export class LocaleInterceptor implements HttpInterceptor {
   private transloco = inject(TranslocoService);
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    console.log('🏷️ LocaleInterceptor:', this.transloco.getActiveLang(), '->', req.url);
     const lang = this.transloco.getActiveLang();
-    const cloned = req.clone({ headers: req.headers.set('Accept-Language', lang) });
+    const cloned = req.clone({
+      headers: req.headers.set('X-Locale', lang),
+      withCredentials: true
+    });
+
     return next.handle(cloned);
   }
 }

--- a/src/PersonalSite.Web/Program.cs
+++ b/src/PersonalSite.Web/Program.cs
@@ -10,9 +10,9 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowFrontend",
         policy => policy
             .WithOrigins("http://localhost:4200")
+            .AllowCredentials()
             .AllowAnyHeader()
-            .AllowAnyMethod()
-            .AllowCredentials());
+            .AllowAnyMethod());
 });
 
 builder.Configuration


### PR DESCRIPTION
… dynamic locale handling, and improve language awareness in components

- Removed `AcceptLanguageInterceptor` in favor of the more robust `LocaleInterceptor` to include `X-Locale` header and credentials in requests.
- Updated `LocalizationMiddleware` to prioritize `X-Locale`, fallback to cookies, and gracefully handle both `Accept-Language` and default logic.
- Enhanced `PrivacyComponent` and `CookiesComponent` to respond to `langChanged` events for dynamic reloading of content based on the active language.
- Added `withInterceptorsFromDi` to `app.config.ts` for improved interceptor configuration.
- Refined language switching logic in `LanguageSwitcherComponent` for better maintainability and performance.