### PR TITLE
Add Portfolio module with project detail view and updated routing

### DIFF
--- a/frontend/public-site/public/assets/i18n/en.json
+++ b/frontend/public-site/public/assets/i18n/en.json
@@ -57,9 +57,31 @@
       "message": "Message is required"
     }
   },
-  "blog" : {
+  "button": {
     "read": "Read",
     "share": "Share",
-    "close": "Close"
+    "close": "Close",
+    "read_more": "Read More",
+    "copied": "Link copied!",
+    "tooltip": {
+      "linkedin": "Share on LinkedIn",
+      "facebook": "Share on Facebook",
+      "copy_link": "Copy link"
+    }
+  },
+  "project": {
+    "overview": "Project overview",
+    "technologies": "Used technologies",
+    "features": "Main features",
+    "architecture": "Project architecture",
+    "deployment": "Deployment",
+    "skills": "Skills"
+  },
+  "skill": {
+    "category": {
+      "languages": "Languages",
+      "frameworks": "Frameworks",
+      "tools": "Tools"
+    }
   }
 }

--- a/frontend/public-site/public/assets/i18n/pl.json
+++ b/frontend/public-site/public/assets/i18n/pl.json
@@ -57,10 +57,32 @@
       "message": "Wiadomość jest wymagana"
     }
   },
-  "blog": {
+  "button": {
     "read": "Czytaj",
     "share": "Udostępnij",
-    "close": "Zamknij"
+    "close": "Zamknij",
+    "read_more": "Czytaj więcej",
+    "copied": "Link skopiowany!",
+    "tooltip": {
+      "linkedin": "Udostępnij na LinkedIn",
+      "facebook": "Udostępnij na Facebooku",
+      "copy_link": "Skopiuj link"
+    }
+  },
+  "project": {
+    "overview": "Przegląd projektu",
+    "technologies": "Użyte technologie",
+    "features": "Główne funkcje",
+    "architecture": "Architektura projektu",
+    "deployment": "Wdrożenie",
+    "skills": "Umiejętności"
+  },
+  "skill": {
+    "category": {
+      "languages": "Języki",
+      "frameworks": "Frameworki",
+      "tools": "Narzędzia"
+    }
   }
 }
 

--- a/frontend/public-site/public/assets/i18n/ru.json
+++ b/frontend/public-site/public/assets/i18n/ru.json
@@ -57,9 +57,31 @@
       "message": "Сообщение обязательно для заполнения"
     }
   },
-  "blog": {
+  "button": {
     "read": "Читать",
     "share": "Поделиться",
-    "close": "Закрыть"
+    "close": "Закрыть",
+    "read_more": "Читать далее",
+    "copied": "Ссылка скопирована!",
+    "tooltip": {
+      "linkedin": "Поделиться в LinkedIn",
+      "facebook": "Поделиться в Facebook",
+      "copy_link": "Скопировать ссылку"
+    }
+  },
+  "project": {
+    "overview": "Обзор проекта",
+    "technologies": "Используемые технологии",
+    "features": "Основные функции",
+    "architecture": "Архитектура проекта",
+    "deployment": "Развертывание",
+    "skills": "Навыки"
+  },
+  "skill": {
+    "category": {
+      "languages": "Языки",
+      "frameworks": "Фреймворки",
+      "tools": "Инструменты"
+    }
   }
 }

--- a/frontend/public-site/public/assets/i18n/uk.json
+++ b/frontend/public-site/public/assets/i18n/uk.json
@@ -57,9 +57,31 @@
       "message": "Повідомлення є обов’язковим"
     }
   },
-  "blog": {
+  "button": {
     "read": "Читати",
     "share": "Поділитися",
-    "close": "Закрити"
+    "close": "Закрити",
+    "read_more": "Читати далі",
+    "copied": "Посилання скопійовано!",
+    "tooltip": {
+      "linkedin": "Поділитися в LinkedIn",
+      "facebook": "Поділитися у Facebook",
+      "copy_link": "Скопіювати посилання"
+    }
+  },
+  "project": {
+    "overview": "Огляд проєкту",
+    "technologies": "Використані технології",
+    "features": "Основні функції",
+    "architecture": "Архітектура проєкту",
+    "deployment": "Розгортання",
+    "skills": "Навички"
+  },
+  "skill": {
+    "category": {
+      "languages": "Мови",
+      "frameworks": "Фреймворки",
+      "tools": "Інструменти"
+    }
   }
 }

--- a/frontend/public-site/public/assets/styles/abstracts/_variables.scss
+++ b/frontend/public-site/public/assets/styles/abstracts/_variables.scss
@@ -11,6 +11,8 @@
   --color-social-link-inner: #D9D9D9;
   --color-title: #3B3B3B;
   --color-text-grey: #8A8A8A;
+  --color-skill-background: #8A8A8A;
+  --color-skill-text: #F8F8F8;
 
   --color-hover: #41ECFF;
   --color-active: #76FF9F;
@@ -34,4 +36,5 @@ body[data-theme="dark"] {
   --color-social-link-outer: #C5C5C5;
   --color-social-link-inner: #3B3B3B;
   --color-title: #F8F8F8;
+  --color-skill-background: #636363;
 }

--- a/frontend/public-site/src/app/app.routes.ts
+++ b/frontend/public-site/src/app/app.routes.ts
@@ -16,7 +16,17 @@ export const routes: Routes = [
     children: [
       { path: '', component: HomeComponent, pathMatch: 'full' },
       { path: 'about', component: AboutComponent, data: { title: 'About'} },
-      { path: 'portfolio', component: PortfolioComponent, data: { title: 'Portfolio'} },
+      {
+        path: 'portfolio',
+        component: PortfolioComponent,
+        data: { title: 'Portfolio'},
+        children: [
+          {
+            path: ':slug',
+            loadComponent: () => import('./features/portfolio/project.component/project.component').then(m => m.ProjectComponent)
+          }
+        ]
+      },
       {
         path: 'blog',
         component: BlogComponent,

--- a/frontend/public-site/src/app/features/blog/blog-post.component/blog-post.component.html
+++ b/frontend/public-site/src/app/features/blog/blog-post.component/blog-post.component.html
@@ -1,6 +1,6 @@
 @if (post$ | async; as post) {
   <div class="blog-detail-dialog">
-    <button mat-button (click)="onCloseClick()">{{ 'blog.close' | transloco }}</button>
+    <button mat-button (click)="onCloseClick()">{{ 'button.close' | transloco }}</button>
 
     <div
       class="blog-cover-img"

--- a/frontend/public-site/src/app/features/blog/blog.component/blog.component.html
+++ b/frontend/public-site/src/app/features/blog/blog.component/blog.component.html
@@ -16,7 +16,7 @@
             <button
               class="btn btn-primary"
               (click)="onReadClick(post.slug)">
-              {{ 'blog.read' | transloco }}
+              {{ 'button.read' | transloco }}
             </button>
 
             <app-share-popover
@@ -24,7 +24,7 @@
               [label]="post.title"
             >
               <button class="btn btn-secondary" type="button">
-                {{ 'blog.share' | transloco }}
+                {{ 'button.share' | transloco }}
               </button>
             </app-share-popover>
           </div>

--- a/frontend/public-site/src/app/features/blog/blog.component/blog.component.scss
+++ b/frontend/public-site/src/app/features/blog/blog.component/blog.component.scss
@@ -162,11 +162,11 @@ $blog-lg: 1007px;
   }
 
   .btn-primary {
-    width: 9.5rem;
+    width: 9rem;
   }
 
   .btn-secondary {
-    width: 5.9375rem;
+    width: 6.5rem;
   }
 }
 
@@ -193,8 +193,14 @@ $blog-lg: 1007px;
     height: 15.875rem;
   }
 
+  .blog-detail-title {
+    width: 35.6875rem;
+    height: 3.75rem;
+  }
+
   .blog-detail-description {
     width: 35.6875rem;
+    height: 6.4375rem;
     -webkit-line-clamp: 4;
   }
 

--- a/frontend/public-site/src/app/features/blog/share-link.component/share-link.component.html
+++ b/frontend/public-site/src/app/features/blog/share-link.component/share-link.component.html
@@ -3,9 +3,12 @@
     type="button"
     aria-label="Share on LinkedIn"
     (click)="onShareLinkedIn()"
+    mat-icon-button
+    [matTooltip]="'button.tooltip.linkedin' | transloco"
+    matTooltipShowDelay="500"
     class="share-btn"
   >
-    <svg width="57" height="58" viewBox="0 0 57 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="57" height="58" viewBox="0 0 57 58" xmlns="http://www.w3.org/2000/svg">
       <g filter="url(#filter0_di_567_4880)">
         <rect x="4.88013" y="2.93985" width="48.1203" height="48.1203" rx="12.8" fill="#3B3B3B"/>
         <path d="M20.0463 43.156H12.7853V21.502H20.0463V43.156Z" fill="#C5C5C5"/>
@@ -36,9 +39,12 @@
     type="button"
     aria-label="Share on Facebook"
     (click)="onShareFacebook()"
+    mat-icon-button
+    [matTooltip]="'button.tooltip.facebook' | transloco"
+    matTooltipShowDelay="500"
     class="share-btn"
   >
-    <svg width="57" height="58" viewBox="0 0 57 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="57" height="58" viewBox="0 0 57 58" xmlns="http://www.w3.org/2000/svg">
       <g filter="url(#filter0_di_567_4878)">
         <rect x="4.75977" y="2.93985" width="48.1203" height="48.1203" rx="12.8" fill="#3B3B3B"/>
         <path d="M38.2977 33.3392L39.4367 26.1325H32.3114V21.4557C32.3114 19.4841 33.3067 17.5623 36.4981 17.5623H39.7378V11.4268C39.7378 11.4268 36.7977 10.9398 33.9868 10.9398C28.1185 10.9398 24.2829 14.3913 24.2829 20.6398V26.1325H17.7598V33.3392H24.2829L24.3118 50.6545H32.3403L32.3114 33.3392H38.2977Z" fill="#C5C5C5"/>
@@ -68,9 +74,12 @@
     type="button"
     aria-label="Copy link"
     (click)="onCopyLink()"
+    mat-icon-button
+    [matTooltip]="'button.tooltip.copy_link' | transloco"
+    matTooltipShowDelay="500"
     class="share-btn"
   >
-    <svg width="57" height="58" viewBox="0 0 57 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="57" height="58" viewBox="0 0 57 58" xmlns="http://www.w3.org/2000/svg">
       <g filter="url(#filter0_di_567_4882)">
         <rect x="4.00049" y="2.94" width="48.12" height="48.12" rx="12.8" fill="#3B3B3B"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M36.6676 9.00055C36.6736 9.00055 36.6795 9.00194 36.6854 9.00215C36.8176 9.00292 36.9447 9.05248 37.0399 9.15835L42.9346 15.2204C43.0621 15.3465 43.1026 15.5291 43.0585 15.705V37.4652C43.0584 37.7287 42.8455 37.9394 42.5615 37.9394H36.8092V44.6166C36.7914 44.8624 36.5783 45.0906 36.2945 45.0908H13.4974C13.2135 45.0907 13.0006 44.8624 13.0005 44.599V16.6438C13.0005 16.3627 13.2312 16.152 13.4974 16.1519H19.2853V9.49237C19.2854 9.21129 19.5168 9.00055 19.7831 9.00055H36.6676ZM14.0122 44.0895H35.7967V23.18H29.9562C29.6722 23.18 29.4585 22.9517 29.4584 22.6882V17.118H14.0122V44.0895ZM20.2801 16.1519H29.8243C29.8664 16.1405 29.9111 16.1343 29.9562 16.1343C30.1459 16.1344 30.3036 16.2364 30.3876 16.3826L36.649 22.3542C36.7555 22.442 36.8092 22.5828 36.8092 22.7058V36.9557H42.0646V16.0462H36.6676C36.3835 16.0462 36.1698 15.8179 36.1698 15.5544V9.98419H20.2801V16.1519ZM30.4532 22.1964H35.061L30.4532 17.7964V22.1964ZM37.1646 15.045H41.3717L37.1646 10.7227V15.045Z" fill="#3B3B3B"/>

--- a/frontend/public-site/src/app/features/blog/share-link.component/share-link.component.ts
+++ b/frontend/public-site/src/app/features/blog/share-link.component/share-link.component.ts
@@ -1,10 +1,18 @@
 import {Component, inject, Input} from '@angular/core';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import { Clipboard } from '@angular/cdk/clipboard';
+import {TranslocoPipe, TranslocoService} from '@ngneat/transloco';
+import {MatIconButton} from '@angular/material/button';
+import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-share-links',
-  imports: [],
+  standalone: true,
+  imports: [
+    MatIconButton,
+    MatTooltip,
+    TranslocoPipe
+  ],
   templateUrl: './share-link.component.html',
   styleUrl: './share-link.component.scss'
 })
@@ -15,6 +23,7 @@ export class ShareLinkComponent {
 
   private clipboard = inject(Clipboard);
   private snackBar = inject(MatSnackBar);
+  private transloco = inject(TranslocoService)
 
   onShareLinkedIn(): void {
     const shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(this.url)}`;
@@ -31,7 +40,10 @@ export class ShareLinkComponent {
       ? `${this.label} – ${this.url}`
       : this.url;
     this.clipboard.copy(textToCopy);
-    this.snackBar.open(`Link copied!`, undefined, { duration: 2000 });
+    this.snackBar.open(
+      this.transloco.translate('button.copied'),
+      undefined,
+      { duration: 2000 });
   }
 
 

--- a/frontend/public-site/src/app/features/portfolio/portfolio.component/portfolio.component.html
+++ b/frontend/public-site/src/app/features/portfolio/portfolio.component/portfolio.component.html
@@ -1,1 +1,42 @@
-<p>portfolio.component works!</p>
+@if(!hasDetail)
+{
+  @if (projects$ | async; as projects) {
+    <div class="portfolio-page">
+      @for (project of projects; track trackBySlug($index, project)) {
+        <div class="project-card">
+          <div class="project-card-content">
+            <div
+              class="project-cover-img"
+              [ngStyle]="{ 'background-image': 'url(' + project.coverImage + ')' }"
+              aria-hidden="true"
+            ></div>
+
+            <h6 class=" project-title">{{ project.title }}</h6>
+
+            <div
+              class="project-skills"
+              [class.expanded]="expandedProjectId === project.id"
+              (mouseenter)="onMouseEnter(project.id)"
+              (mouseleave)="onMouseLeave()">
+              @for (skill of project.skills; track skill.skill.key) {
+                <app-skill [skill]="skill.skill"></app-skill>
+              }
+            </div>
+
+            <p class="project-description">{{ project.shortDescription }}</p>
+
+            <button
+              class="btn btn-primary"
+              (click)="onReadClick(project.slug)">
+              {{ 'button.read_more' | transloco }}
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  }
+} @else {
+  <div class="project-area">
+    <router-outlet></router-outlet>
+  </div>
+}

--- a/frontend/public-site/src/app/features/portfolio/portfolio.component/portfolio.component.scss
+++ b/frontend/public-site/src/app/features/portfolio/portfolio.component/portfolio.component.scss
@@ -1,0 +1,210 @@
+$portfolio-sm: 640px;
+$portfolio-lg: 1007px;
+
+$skill-item-height: 3rem;
+
+.portfolio-page {
+  display: flex;
+  justify-items: center;
+  width: 100%;
+  max-width: 20rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin: 2rem auto;
+}
+
+.project-card {
+  width: 100%;
+
+  height: fit-content;
+  padding: 0.625rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0.625rem;
+  align-self: stretch;
+
+  border-radius: 1.25rem;
+  background: var(--color-footer-background);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+}
+
+.project-card-content {
+  display: grid;
+  grid-template-areas:
+    "image"
+    "title"
+    "skills"
+    "description"
+    "button_read";
+  grid-template-columns: 1fr;
+  grid-template-rows:
+    auto
+    auto
+    auto
+    min-content
+    min-content;
+
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  align-self: stretch;
+}
+
+.project-cover-img {
+  width: auto;
+  height: 10.55825rem;
+  background-size: cover;
+  align-self: stretch;
+
+  border-radius: 0.625rem;
+  grid-area: image;
+}
+
+.project-title {
+  color: var(--color-text-primary);
+  font-size: 1.75rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  margin: 0;
+  grid-area: title;
+}
+
+.project-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+
+  max-height: calc(2 * $skill-item-height);
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  position: relative;
+  grid-area: skills;
+}
+
+.project-skills.expanded {
+  max-height: 1000px;
+  overflow: visible;
+}
+
+.project-skills::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2rem;
+  background: linear-gradient(to bottom, transparent, white);
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.project-skills.expanded::after {
+  opacity: 0;
+}
+
+.project-description {
+  display: -webkit-box;
+  width: 18.4375rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+
+  overflow: hidden;
+  color: var(--color-text-primary);
+  text-overflow: ellipsis;
+  font-size: 1.1275rem;
+  grid-area: description;
+}
+
+.btn {
+  display: flex;
+  padding: 0.625rem 1.25rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  align-self: stretch;
+  border-radius: 0.625rem;
+  box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.10) inset, 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+  color: var(--color-modal-text);
+  font-size: 1.125rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  text-transform: capitalize;
+
+  &:hover {
+    background: var(--color-hover);
+    color: var(--color-hover-text);
+  }
+}
+
+.btn-primary {
+  background: var(--color-modal-button);
+  grid-area: button_read;
+  width: 18.725rem;
+}
+
+
+@media (min-width: $portfolio-sm) {
+  .portfolio-page {
+    max-width: 48rem;
+  }
+
+  .project-card {
+    width: 35rem;
+    padding: 1.25rem;
+    align-items: center;
+    gap: 1.25rem;
+  }
+
+  .project-cover-img {
+    width: 32.5rem;
+    height: 18.275rem;
+  }
+
+  .project-description {
+    width: 32.5rem;
+  }
+
+  .btn-primary {
+    width: 32.5rem;
+  }
+}
+
+@media (min-width: $portfolio-lg) {
+  .portfolio-page {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem;
+    max-width: 80rem;
+  }
+
+  .project-title {
+    height: 4.525rem;
+  }
+
+  .project-description {
+    -webkit-line-clamp: 3;
+    height: 4.725rem;
+  }
+}
+
+.project-area {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 20rem;
+  margin: 2rem auto;
+
+  @media (min-width: $portfolio-sm) {
+    max-width: 38rem;
+  }
+
+  @media (min-width: $portfolio-lg) {
+    max-width: 62rem;
+  }
+}

--- a/frontend/public-site/src/app/features/portfolio/project.component/project.component.html
+++ b/frontend/public-site/src/app/features/portfolio/project.component/project.component.html
@@ -1,0 +1,65 @@
+@if (project$ | async; as project) {
+  <div class="project-dialog">
+    <button mat-button (click)="onCloseClick()">{{ 'button.close' | transloco }}</button>
+
+    <div
+      class="project-cover-img"
+      [ngStyle]="{ 'background-image': 'url(' + project.coverImage + ')' }"
+      aria-hidden="true"
+    ></div>
+
+    <h3 class="project-title">{{ project.title }}</h3>
+
+    <div class="project-description">
+      <h6 class="project-subtitle">{{ 'project.overview' | transloco }}</h6>
+      <p class="project-content">{{ project.descriptionSections['Overview'] }}</p>
+      <h6 class="project-subtitle">{{ 'project.technologies' | transloco }}</h6>
+      <p class="project-content">{{ project.descriptionSections['Technologies'] }}</p>
+      <h6 class="project-subtitle">{{ 'project.features' | transloco }}</h6>
+      <p class="project-content">{{ project.descriptionSections['Features'] }}</p>
+      <h6 class="project-subtitle">{{ 'project.architecture' | transloco }}</h6>
+      <p class="project-content">{{ project.descriptionSections['Architecture'] }}</p>
+      <h6 class="project-subtitle">{{ 'project.deployment' | transloco }}</h6>
+      <p class="project-content">{{ project.descriptionSections['Deployment'] }}</p>
+    </div>
+
+    @if (skillsByCategory$ | async; as skillsByCategory) {
+      <h4 class="project-skills-title">{{ 'project.skills' | transloco }}</h4>
+
+      <div class="project-skills">
+        <div class="skills-category-section">
+          <h5 class="skill-category">{{ 'skill.category.languages' | transloco }}</h5>
+          <div class="category-skills">
+            @for (skill of skillsByCategory['Languages']; track skill.skill.key)  {
+              <app-skill [skill]="skill.skill"></app-skill>
+            }
+          </div>
+        </div>
+
+        <div class="skills-category-section">
+          <h5 class="skill-category">{{ 'skill.category.frameworks' | transloco }}</h5>
+          <div class="category-skills">
+            @for (skill of skillsByCategory['Frameworks']; track skill.skill.key)  {
+              <app-skill [skill]="skill.skill"></app-skill>
+            }
+          </div>
+        </div>
+
+        <div class="skills-category-section">
+          <h5 class="skill-category">{{ 'skill.category.tools' | transloco }}</h5>
+          <div class="category-skills">
+            @for (skill of skillsByCategory['Tools']; track skill.skill.key)  {
+              <app-skill [skill]="skill.skill"></app-skill>
+            }
+          </div>
+        </div>
+      </div>
+    }
+
+    <app-share-links
+      [url]="currentUrl()"
+      [label]="project.title"
+      [iconSize]="iconSize"
+    ></app-share-links>
+  </div>
+}

--- a/frontend/public-site/src/app/features/portfolio/project.component/project.component.scss
+++ b/frontend/public-site/src/app/features/portfolio/project.component/project.component.scss
@@ -1,0 +1,129 @@
+.project-dialog {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+
+  button {
+    display: flex;
+    align-self: stretch;
+    margin-bottom: 0.5rem;
+    border: none;
+    background: var(--color-modal-button);
+    color: var(--color-modal-text);
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 1.25rem;
+    border-radius: 0.875rem;
+    box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.10) inset, 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+    justify-content: center;
+    align-items: center;
+    gap: 0.625rem;
+
+    &:hover {
+      background: var(--color-hover);
+      color: var(--color-hover-text);
+    }
+  }
+
+  .project-cover-img {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    align-self: stretch;
+    background-size: cover;
+    background-position: center;
+    padding-top: 56.25%;
+    border-radius: 0.625rem;
+    grid-area: image;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    display: block;
+  }
+
+  .project-title {
+    font-size: 1.975rem;
+    margin: 0 0 1.5rem 0;
+    word-break: break-word;
+  }
+
+  .project-description {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+
+    .project-subtitle {
+      font-size: 1.225rem;
+      word-break: break-word;
+    }
+
+    .project-content {
+      flex: 1;
+      overflow-y: auto;
+      font-size: 1rem;
+      line-height: 1.5;
+      text-align: justify;
+      white-space: pre-line;
+    }
+  }
+
+  .project-skills-title {
+    font-size: 1.975rem;
+    margin: 0 0 1rem 0;
+    word-break: break-word;
+  }
+
+  .project-skills {
+    display: flex;
+    padding: 1.25rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2.5rem;
+    align-self: stretch;
+
+    border-radius: 1.25rem;
+    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25) inset;
+
+    .skills-category-section {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      gap: 1.25rem;
+      align-self: stretch;
+    }
+
+    .skill-category {
+      font-size: 1.4725rem;
+      word-break: break-word;
+      margin: 0;
+    }
+
+    .category-skills {
+      display: flex;
+      align-items: center;
+      align-content: center;
+      gap: 0.725rem;
+      align-self: stretch;
+      flex-wrap: wrap;
+    }
+  }
+
+  app-share-links {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    align-self: center;
+  }
+}
+
+.project-dialog .project-cover-img,
+.project-dialog button,
+.project-dialog .category-skills {
+  max-width: 100%;
+}
+

--- a/frontend/public-site/src/app/features/portfolio/project.component/project.component.spec.ts
+++ b/frontend/public-site/src/app/features/portfolio/project.component/project.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectComponent } from './project.component';
+
+describe('ProjectComponent', () => {
+  let component: ProjectComponent;
+  let fixture: ComponentFixture<ProjectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/public-site/src/app/features/portfolio/project.component/project.component.ts
+++ b/frontend/public-site/src/app/features/portfolio/project.component/project.component.ts
@@ -1,0 +1,91 @@
+import {Component, DOCUMENT, inject, PLATFORM_ID} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+import {PagesApiService} from '../../../core/services/pages-api.service';
+import {Meta, Title} from '@angular/platform-browser';
+import {switchMap, tap} from 'rxjs/operators';
+import {map, of} from 'rxjs';
+import {AsyncPipe, isPlatformBrowser, NgStyle} from '@angular/common';
+import {MatButton} from '@angular/material/button';
+import {ShareLinkComponent} from '../../blog/share-link.component/share-link.component';
+import {TranslocoPipe} from '@ngneat/transloco';
+import {ProjectSkillDto} from '../../../shared/models/page-dtos';
+import {SkillComponent} from '../../../shared/components/skills/skill.component/skill.component';
+
+@Component({
+  selector: 'app-project',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    MatButton,
+    ShareLinkComponent,
+    TranslocoPipe,
+    NgStyle,
+    SkillComponent
+  ],
+  templateUrl: './project.component.html',
+  styleUrl: './project.component.scss'
+})
+export class ProjectComponent {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private api = inject(PagesApiService);
+  private meta = inject(Meta);
+  private titleService = inject(Title);
+  private platformId = inject(PLATFORM_ID);
+  private document = inject(DOCUMENT);
+
+  readonly project$ = this.route.paramMap.pipe(
+    switchMap(params => {
+      const slug = params.get('slug');
+      if (!slug) return of(null);
+
+      return this.api.portfolioPage$.pipe(
+        map(page => page.projects.find(p => p.slug === slug) ?? null),
+        tap(project => {
+          if (project) {
+            this.titleService.setTitle(project.metaTitle);
+            this.meta.updateTag({ name: 'description', content: project.metaDescription });
+            this.meta.updateTag({ property: 'og:image', content: project.ogImage });
+          }
+        })
+      );
+    })
+  );
+
+  readonly skills$ = this.project$.pipe(
+    map(project => project?.skills ?? [])
+  );
+
+  readonly skillsByCategory$ = this.skills$.pipe(
+    map(skills => {
+      const grouped: Record<string, ProjectSkillDto[]> = {
+        Languages: [],
+        Tools: [],
+        Frameworks: []
+      };
+
+      for (const skill of skills) {
+        const key = skill.skill.category.key;
+        if (grouped[key]) {
+          grouped[key].push(skill);
+        }
+      }
+
+      return grouped;
+    })
+  );
+
+  currentUrl(): string {
+    if (isPlatformBrowser(this.platformId)) {
+      return this.document.location.href;
+    } else {
+      return '';
+    }
+  }
+
+  iconSize = '3.0075rem';
+
+  onCloseClick(): void {
+    void this.router.navigate(['../'], { relativeTo: this.route });
+  }
+}

--- a/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.html
+++ b/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.html
@@ -1,0 +1,7 @@
+@if (skill) {
+  <div
+    class="skill-item"
+    [title]="skill.description">
+    <span class="skill-name">{{ skill.name }}</span>
+  </div>
+}

--- a/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.scss
+++ b/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.scss
@@ -1,0 +1,21 @@
+.skill-item {
+  display: flex;
+  padding: 0.625rem 1.25rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  border-radius: 0.5625rem;
+  background: var(--color-skill-background);
+}
+
+.skill-name {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-self: stretch;
+  color: var(--color-skill-text);
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}

--- a/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.spec.ts
+++ b/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillComponent } from './skill.component';
+
+describe('SkillComponent', () => {
+  let component: SkillComponent;
+  let fixture: ComponentFixture<SkillComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SkillComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SkillComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.ts
+++ b/frontend/public-site/src/app/shared/components/skills/skill.component/skill.component.ts
@@ -1,0 +1,13 @@
+import {Component, Input} from '@angular/core';
+import {SkillDto} from '../../../models/page-dtos';
+
+@Component({
+  selector: 'app-skill',
+  standalone: true,
+  imports: [],
+  templateUrl: './skill.component.html',
+  styleUrl: './skill.component.scss'
+})
+export class SkillComponent {
+  @Input() skill?: SkillDto;
+}


### PR DESCRIPTION
- Introduced `ProjectComponent` for displaying individual project details with responsive UI and rich metadata.
- Added dynamic child route to `PortfolioComponent` for project detail pages using `portfolio/:slug`.
- Implemented `SkillComponent` for showcasing project-specific skills.
- Enhanced `PortfolioComponent` with hover effects, improved link sharing, and dynamic project card layouts.
- Updated SCSS for portfolio and project components to improve responsiveness and styling consistency.
- Added unit tests for `ProjectComponent` and `SkillComponent`.
- Updated `ShareLinkComponent` with better localization and tooltips.