### PR TITLE
Add dynamic SEO and JSON-LD schema to Cookies and Privacy components

### DIFF
--- a/frontend/public-site/src/app/features/cookies/cookies.component/cookies.component.ts
+++ b/frontend/public-site/src/app/features/cookies/cookies.component/cookies.component.ts
@@ -1,6 +1,8 @@
-import {Component, inject} from '@angular/core';
+import {Component, computed, inject, OnInit} from '@angular/core';
 import {PagesApiService} from '../../../core/services/pages-api.service';
 import {AsyncPipe} from '@angular/common';
+import {MetaService} from '../../../core/services/meta.service';
+import {SiteInfoService} from '../../../core/services/site-info.service';
 
 @Component({
   selector: 'app-cookies',
@@ -11,6 +13,32 @@ import {AsyncPipe} from '@angular/common';
   ],
   styleUrl: './cookies.component.scss'
 })
-export class CookiesComponent {
+export class CookiesComponent implements OnInit {
   readonly page$ = inject(PagesApiService).cookiesPage$;
+  private metaService = inject(MetaService);
+  private svc = inject(SiteInfoService);
+
+  socialLinks = computed(() => this.svc.siteInfo()?.socialLinks ?? []);
+  private readonly sameAs = this.socialLinks()
+    .filter(link => link.isActive)
+    .map(link => link.url);
+
+  ngOnInit() {
+    this.page$.subscribe(page => {
+      this.metaService.setSeo({
+        title: page.pageData.metaTitle || 'Cookies Policy | Hryhorii Kyrylchenko',
+        description: page.pageData.metaDescription || 'Personal portfolio cookies page',
+        imageUrl: page.pageData.ogImage || undefined,
+        url: window.location.href,
+        type: 'article',
+        jsonLd: {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Hryhorii Kyrylchenko",
+          "url": window.location.href,
+          "sameAs": this.sameAs
+        }
+      });
+    });
+  }
 }

--- a/frontend/public-site/src/app/features/privacy/privacy.component/privacy.component.ts
+++ b/frontend/public-site/src/app/features/privacy/privacy.component/privacy.component.ts
@@ -1,6 +1,8 @@
-import {Component, inject} from '@angular/core';
+import {Component, computed, inject, OnInit} from '@angular/core';
 import {PagesApiService} from '../../../core/services/pages-api.service';
 import {AsyncPipe} from '@angular/common';
+import {MetaService} from '../../../core/services/meta.service';
+import {SiteInfoService} from '../../../core/services/site-info.service';
 
 @Component({
   selector: 'app-privacy',
@@ -11,6 +13,32 @@ import {AsyncPipe} from '@angular/common';
   ],
   styleUrl: './privacy.component.scss'
 })
-export class PrivacyComponent {
+export class PrivacyComponent implements OnInit {
   readonly page$ = inject(PagesApiService).privacyPage$;
+  private metaService = inject(MetaService);
+  private svc = inject(SiteInfoService);
+
+  socialLinks = computed(() => this.svc.siteInfo()?.socialLinks ?? []);
+  private readonly sameAs = this.socialLinks()
+    .filter(link => link.isActive)
+    .map(link => link.url);
+
+  ngOnInit() {
+    this.page$.subscribe(page => {
+      this.metaService.setSeo({
+        title: page.pageData.metaTitle || 'Privacy Policy | Hryhorii Kyrylchenko',
+        description: page.pageData.metaDescription || 'Personal portfolio privacy page',
+        imageUrl: page.pageData.ogImage || undefined,
+        url: window.location.href,
+        type: 'article',
+        jsonLd: {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Hryhorii Kyrylchenko",
+          "url": window.location.href,
+          "sameAs": this.sameAs
+        }
+      });
+    });
+  }
 }


### PR DESCRIPTION
- Integrated `MetaService` for dynamic SEO updates including meta tags and Open Graph data.
- Added JSON-LD schema generation for both components with `sameAs` links from `SiteInfoService`.
- Enhanced `ngOnInit` lifecycle to configure SEO metadata based on fetched page data.