### PR TITLE
Handle missing `package-lock.json` in deploy workflow by falling back…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Build frontend
         working-directory: ./frontend
         run: |
-          npm ci
+          if [ -f package-lock.json ]; then
+      	    npm ci
+          else
+            npm install
+          fi
           npm run build -- --configuration production
 
       - name: Setup .NET


### PR DESCRIPTION
… to `npm install`